### PR TITLE
[LED-31] Split active and raw transaction operations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "text": "Commit message must follow the format: 'LED-XXXXX type(scope): subject'. Extract the ticket number from the current branch name (pattern: LED-XXXXX-description). Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional (e.g. fullscreen, mobile, platform-core). Subject must be in imperative mood, lowercase, no period at the end."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ For detailed domain model documentation, see [Domain Documentation](./docs/DOMAI
 - Each operation tracks amounts in both original and base currencies
 - MVP deletion semantics:
   - transactions use soft delete (`isTombstone`)
-  - operations may be soft-deleted in storage, but tombstone operations are not part of the domain/read contract and are treated as filtered-out archived rows
+  - operations may be soft-deleted in storage
+  - transaction aggregates keep raw operations for persistence, including tombstone operations
+  - domain business accessors and read APIs expose active operations only
 
 ### Accounts
 - Represents different financial accounts (cash, bank accounts, credit cards)

--- a/apps/backend/src/application/application.errors.ts
+++ b/apps/backend/src/application/application.errors.ts
@@ -11,7 +11,11 @@ export class ApplicationError extends BaseError {}
  */
 export class EntityNotFoundError extends ApplicationError {
   constructor(entityName: string, description?: string) {
-    super(`${entityName} not found ${description ? `: ${description}` : ''}`);
+    super(
+      description
+        ? `${entityName} not found: ${description}`
+        : `${entityName} not found`,
+    );
   }
 }
 

--- a/apps/backend/src/application/usecases/transaction/GetTransactionById.ts
+++ b/apps/backend/src/application/usecases/transaction/GetTransactionById.ts
@@ -1,10 +1,10 @@
 import { UUID } from '@ledgerly/shared/types';
 import {
-  EntityNotFoundError,
   TransactionResponseDTO,
   TransactionViewMapper,
   TransactionQueryRepositoryInterface,
 } from 'src/application';
+import { EntityNotFoundError } from 'src/application/application.errors';
 
 export class GetTransactionByIdUseCase {
   constructor(

--- a/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
@@ -1,8 +1,8 @@
 import {
-  EntityNotFoundError,
   TransactionResponseDTO,
   TransactionQueryRepositoryInterface,
 } from 'src/application';
+import { EntityNotFoundError } from 'src/application/application.errors';
 import { OperationDbRow, TransactionWithRelations } from 'src/db/schema';
 import {
   Amount,

--- a/apps/backend/src/db/test-db.ts
+++ b/apps/backend/src/db/test-db.ts
@@ -218,10 +218,10 @@ export class TestDB {
   createTransactionWithOperations = async (
     userId: UUID,
     params?: {
-      description: string;
-      postingDate: IsoDateString;
-      transactionDate: IsoDateString;
-      currencyCode: CurrencyCode;
+      description?: string;
+      postingDate?: IsoDateString;
+      transactionDate?: IsoDateString;
+      currencyCode?: CurrencyCode;
       isTombstone?: boolean;
       operations: {
         accountId: UUID;

--- a/apps/backend/src/domain/operations/operation.entity.test.ts
+++ b/apps/backend/src/domain/operations/operation.entity.test.ts
@@ -13,6 +13,7 @@ import {
 
 import { Account } from '../accounts';
 import { Amount, Id } from '../domain-core';
+import { DeletedEntityOperationError } from '../domain.errors';
 import { Transaction } from '../transactions';
 import { User } from '../users/user.entity';
 
@@ -208,6 +209,33 @@ describe('Operation Domain Entity', () => {
     const updatedSnapshot = operation.toSnapshot();
 
     compareEntities(operationSnapshot, updatedSnapshot);
+  });
+
+  it('should not update a deleted operation', () => {
+    const operation = Operation.create(
+      userId,
+      usdAccount,
+      transaction,
+      Amount.create('100'),
+      Amount.create('300'),
+      'Test operation',
+    );
+
+    operation.markAsDeleted();
+
+    const deletedSnapshot = operation.toSnapshot();
+
+    expect(() =>
+      operation.update({
+        account: eurAccount,
+        amount: Amount.create('150'),
+        description: 'Updated deleted operation',
+        id: operation.id,
+        value: Amount.create('350'),
+      }),
+    ).toThrow(DeletedEntityOperationError);
+
+    expect(operation.toSnapshot()).toEqual(deletedSnapshot);
   });
 
   it('should mark an operation as deleted', () => {

--- a/apps/backend/src/domain/operations/operation.entity.ts
+++ b/apps/backend/src/domain/operations/operation.entity.ts
@@ -8,6 +8,7 @@ import {
   SoftDelete,
   ParentChildRelation,
 } from '../domain-core';
+import { DeletedEntityOperationError } from '../domain.errors';
 
 import { OperationSnapshot, UpdateOperationProps } from './types';
 
@@ -227,6 +228,10 @@ export class Operation {
     if (this.identity.getId().equals(params.id.valueOf()) === false) {
       // TODO: add proper error handling
       throw new Error('Operation ID mismatch');
+    }
+
+    if (this.isDeleted()) {
+      throw new DeletedEntityOperationError('operation', 'update');
     }
 
     const { account, amount, description, value } = params;

--- a/apps/backend/src/domain/transactions/transaction.entity.test.ts
+++ b/apps/backend/src/domain/transactions/transaction.entity.test.ts
@@ -460,7 +460,7 @@ describe('Transaction Domain Entity', () => {
       });
     });
 
-    it('Should delete an existing operation, filter deleted operations from snapshot and increase version', () => {
+    it('Should delete an existing operation, keep it in snapshot and hide it from active operations', () => {
       const transaction = Transaction.create(user.getId(), transactionData);
 
       const originalSnapshot = transaction.toSnapshot();
@@ -472,10 +472,6 @@ describe('Transaction Domain Entity', () => {
 
       const operationsToDeleteIds = operationsToDelete.map((op) =>
         op.valueOf(),
-      );
-
-      const operationsSnapshotFiltered = originalSnapshot.operations.filter(
-        (op) => !operationsToDeleteIds.includes(op.id),
       );
 
       vi.advanceTimersByTime(5000);
@@ -497,19 +493,26 @@ describe('Transaction Domain Entity', () => {
         new Date(updatedSnapshot.updatedAt).getTime(),
       );
 
-      const deletedOperation = operationsSnapshotFiltered.find((op) =>
+      expect(transaction.getOperations()).toHaveLength(
+        originalSnapshot.operations.length - operationsToDeleteIds.length,
+      );
+
+      const deletedOperationSnapshot = updatedSnapshot.operations.filter((op) =>
         operationsToDeleteIds.includes(op.id),
       );
 
-      expect(deletedOperation).not.toBeDefined();
-
-      const deletedOperationSnapshot = updatedSnapshot.operations.filter(
-        (op) => op.id === operationsToDeleteIds[0],
+      expect(deletedOperationSnapshot).toHaveLength(
+        operationsToDeleteIds.length,
       );
+      deletedOperationSnapshot.forEach((op) => {
+        expect(op.isTombstone).toBe(true);
+      });
 
-      expect(deletedOperationSnapshot).toHaveLength(0);
+      originalSnapshot.operations.forEach((op) => {
+        if (operationsToDeleteIds.includes(op.id)) {
+          return;
+        }
 
-      operationsSnapshotFiltered.forEach((op) => {
         expect(operationsToDeleteIds.includes(op.id)).toBe(false);
 
         const matchedPrevOp = updatedSnapshot.operations.find(

--- a/apps/backend/src/domain/transactions/transaction.entity.test.ts
+++ b/apps/backend/src/domain/transactions/transaction.entity.test.ts
@@ -18,7 +18,8 @@ import {
   vi,
 } from 'vitest';
 
-import { Amount, DateValue } from '../domain-core';
+import { Amount, DateValue, Id } from '../domain-core';
+import { DeletedEntityOperationError } from '../domain.errors';
 import {
   CreateOperationProps,
   OperationProps,
@@ -155,6 +156,60 @@ describe('Transaction Domain Entity', () => {
 
       const restoredTransaction = Transaction.restore(transactionSnapshot);
       expect(restoredTransaction.toSnapshot()).toEqual(transactionSnapshot);
+    });
+
+    it('should restore tombstone operations without allowing them to be updated', () => {
+      const transaction = Transaction.create(user.getId(), transactionData);
+      const transactionSnapshot = transaction.toSnapshot();
+      const [operationToDelete, ...activeOperations] =
+        transactionSnapshot.operations;
+
+      const restoredTransaction = Transaction.restore({
+        ...transactionSnapshot,
+        operations: [
+          {
+            ...operationToDelete,
+            isTombstone: true,
+          },
+          ...activeOperations,
+        ],
+      });
+
+      expect(restoredTransaction.getAllOperations()).toHaveLength(
+        transactionSnapshot.operations.length,
+      );
+      expect(restoredTransaction.getOperations()).toHaveLength(
+        activeOperations.length,
+      );
+
+      const operationAccount = data.accountsMap.get(
+        operationToDelete.accountId,
+      );
+
+      if (!operationAccount) {
+        throw new Error('Test setup failed: Account not found');
+      }
+
+      expect(() =>
+        restoredTransaction.applyUpdate(
+          {
+            operations: {
+              create: [],
+              delete: [],
+              update: [
+                {
+                  account: operationAccount,
+                  amount: Amount.create('15000'),
+                  description: 'Updated tombstone operation',
+                  id: Id.fromPersistence(operationToDelete.id),
+                  value: Amount.create('15000'),
+                },
+              ],
+            },
+          },
+          data.transactionContext,
+        ),
+      ).toThrow(DeletedEntityOperationError);
     });
   });
 

--- a/apps/backend/src/domain/transactions/transaction.entity.ts
+++ b/apps/backend/src/domain/transactions/transaction.entity.ts
@@ -149,9 +149,9 @@ export class Transaction {
       version,
     );
 
-    const operations = data.operations
-      .filter((operationData) => !operationData.isTombstone)
-      .map((operationData) => Operation.restore(operationData));
+    const operations = data.operations.map((operationData) =>
+      Operation.restore(operationData),
+    );
 
     transaction.attachOperations(operations);
 
@@ -198,9 +198,7 @@ export class Transaction {
       description: this.description,
       id: this.getId().valueOf(),
       isTombstone: this.isDeleted(),
-      operations: this.operations
-        .filter((operation) => !operation.isDeleted())
-        .map((operation) => operation.toSnapshot()),
+      operations: this.operations.map((operation) => operation.toSnapshot()),
       postingDate: this.postingDate.valueOf(),
       transactionDate: this.transactionDate.valueOf(),
       updatedAt: this.getUpdatedAt().valueOf(),
@@ -436,6 +434,10 @@ export class Transaction {
 
   getOperations(): Operation[] {
     return this.operations.filter((operation) => !operation.isDeleted());
+  }
+
+  getAllOperations(): Operation[] {
+    return [...this.operations];
   }
 
   markAsDeleted(): void {

--- a/apps/backend/src/infrastructure/db/accounts/account.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/accounts/account.repository.test.ts
@@ -177,9 +177,6 @@ describe('AccountRepository', () => {
     });
 
     it.todo('should handle UUID collision gracefully');
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    it.todo('should handle UUID collision gracefully', async () => {});
   });
 
   describe('getAll', () => {

--- a/apps/backend/src/infrastructure/db/operations/operation.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/operations/operation.repository.test.ts
@@ -9,6 +9,7 @@ import {
 import { Transaction, User } from 'src/domain';
 import { Amount } from 'src/domain/domain-core';
 import { OperationSnapshot } from 'src/domain/operations/types';
+import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestDB } from '../../../db/test-db';
@@ -256,6 +257,78 @@ describe('OperationRepository', () => {
 
     it.todo(
       'should update an operation that exists in snapshot and has isTombstone: false with no field changes',
+    );
+
+    it('should reject saving an operation that is already tombstone in the snapshot', async () => {
+      const operations = data.operations.map((operation) =>
+        OperationMapper.toDBRow(operation),
+      );
+
+      await Promise.all(
+        operations.map((operation) => testDB.insertOperation(operation)),
+      );
+
+      const transactionWithRelationsBeforeDelete =
+        await testDB.getTransactionWithRelations(transaction.getId().valueOf());
+
+      const operationsSnapshot = new Map<UUID, OperationSnapshot>();
+
+      transactionWithRelationsBeforeDelete?.operations.forEach((op) => {
+        operationsSnapshot.set(op.id, op);
+      });
+
+      const operationToDelete = operations[0];
+
+      await operationRepository.save(
+        user.id,
+        [
+          {
+            ...operationToDelete,
+            isTombstone: true,
+          },
+        ],
+        operationsSnapshot,
+      );
+
+      const transactionWithRelationsAfterDelete =
+        await testDB.getTransactionWithRelations(transaction.getId().valueOf());
+
+      const tombstoneSnapshot = new Map<UUID, OperationSnapshot>();
+
+      transactionWithRelationsAfterDelete?.operations.forEach((op) => {
+        tombstoneSnapshot.set(op.id, op);
+      });
+
+      const deletedOperation = tombstoneSnapshot.get(operationToDelete.id);
+
+      expect(deletedOperation?.isTombstone).toBe(true);
+
+      await expect(
+        operationRepository.save(
+          user.id,
+          [
+            {
+              ...operationToDelete,
+              isTombstone: true,
+            },
+          ],
+          tombstoneSnapshot,
+        ),
+      ).rejects.toThrow(RepositoryInvariantError);
+
+      const transactionWithRelationsAfterRejectedSave =
+        await testDB.getTransactionWithRelations(transaction.getId().valueOf());
+
+      const operationAfterRejectedSave =
+        transactionWithRelationsAfterRejectedSave?.operations.find(
+          (op) => op.id === operationToDelete.id,
+        );
+
+      expect(operationAfterRejectedSave).toEqual(deletedOperation);
+    });
+
+    it.todo(
+      'should reject updating an operation that is already tombstone in the snapshot',
     );
 
     it.todo(

--- a/apps/backend/src/infrastructure/db/operations/operation.repository.ts
+++ b/apps/backend/src/infrastructure/db/operations/operation.repository.ts
@@ -7,6 +7,7 @@ import {
   operationsTable,
 } from 'src/db/schema';
 import { OperationSnapshot } from 'src/domain/operations/types';
+import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
 
 import { BaseRepository } from '../BaseRepository';
 
@@ -103,6 +104,12 @@ export class OperationRepository
           if (!matchedOperationSnapshot) {
             operationsToInsert.push(operation);
             return;
+          }
+
+          if (matchedOperationSnapshot.isTombstone) {
+            throw new RepositoryInvariantError(
+              `Operation ${operation.id} is already tombstone in persistence snapshot`,
+            );
           }
 
           if (operation.isTombstone) {

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
@@ -11,7 +11,7 @@ import { Account, User } from 'src/domain';
 import { Amount, DateValue, Id } from 'src/domain/domain-core';
 import { OperationSnapshot } from 'src/domain/operations/types';
 import { TransactionBuildContext } from 'src/domain/transactions/types';
-import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
+import { RepositoryNotFoundError } from 'src/infrastructure/infrastructure.errors';
 import { ForeignKeyConstraintError } from 'src/presentation/errors';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -170,7 +170,7 @@ describe('TransactionRepository', () => {
     it('should restore all known operations and expose only active operations through getOperations', async () => {
       const transaction = data.transaction;
 
-      const allOperationsCount = transaction.getOperations().length;
+      const allOperationsCount = transaction.getAllOperations().length;
 
       const acc = transaction
         .getOperations()
@@ -281,13 +281,13 @@ describe('TransactionRepository', () => {
         transaction.getTransactionDate().valueOf(),
       );
 
-      const expectedSnapshots = transaction
+      const expectedOperations = transaction
         .getAllOperations()
         .map((op) => OperationMapper.toDBRow(op));
 
       expect(mockOperationsRepository.save).toHaveBeenCalledWith(
         user.id,
-        expectedSnapshots,
+        expectedOperations,
       );
     });
   });
@@ -417,7 +417,7 @@ describe('TransactionRepository', () => {
 
       await expect(
         transactionRepository.update(anotherUser.id, transaction),
-      ).rejects.toThrow(RepositoryInvariantError);
+      ).rejects.toThrow(RepositoryNotFoundError);
 
       const retrievedTransaction = await transactionRepository.getById(
         data.transaction.getUserId().valueOf(),
@@ -521,7 +521,7 @@ describe('TransactionRepository', () => {
 
       await expect(
         transactionRepository.softDelete(anotherUser.id, transaction),
-      ).rejects.toThrow(RepositoryInvariantError);
+      ).rejects.toThrow(RepositoryNotFoundError);
 
       const retrievedTransaction = await transactionRepository.getById(
         data.transaction.getUserId().valueOf(),

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
@@ -6,7 +6,7 @@ import {
   TransactionBuilder,
   TransactionBuilderResult,
 } from 'src/db/test-utils';
-import { Account, Operation, User } from 'src/domain';
+import { Account, User } from 'src/domain';
 import { Amount, DateValue } from 'src/domain/domain-core';
 import { OperationSnapshot } from 'src/domain/operations/types';
 import { TransactionBuildContext } from 'src/domain/transactions/types';
@@ -40,6 +40,8 @@ describe('TransactionRepository', () => {
   };
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+
     testDB = new TestDB();
 
     await testDB.setupTestDb();
@@ -162,6 +164,10 @@ describe('TransactionRepository', () => {
       });
     });
 
+    it.todo(
+      'should restore all known operations and expose only active operations through getOperations',
+    );
+
     it.todo('should return null when transaction does not exist');
     it.todo('should return null when transaction belongs to another user');
 
@@ -207,7 +213,7 @@ describe('TransactionRepository', () => {
       );
 
       const expectedSnapshots = transaction
-        .getOperations()
+        .getAllOperations()
         .map((op) => op.toSnapshot());
 
       expect(mockOperationsRepository.save).toHaveBeenCalledWith(
@@ -220,17 +226,6 @@ describe('TransactionRepository', () => {
   describe('save', () => {
     it('should update transaction metadata and trigger save', async () => {
       const transaction = data.transaction;
-
-      const initDeletedOperations: Operation[] = [];
-      const initExistedOperations: Operation[] = [];
-
-      transaction.getOperations().forEach((operation) => {
-        if (operation.isDeleted()) {
-          initDeletedOperations.push(operation);
-        } else {
-          initExistedOperations.push(operation);
-        }
-      });
 
       const operations = transaction.getOperations();
 
@@ -320,7 +315,7 @@ describe('TransactionRepository', () => {
 
       const expectedOperations: OperationDbRow[] = [];
 
-      transaction.getOperations().forEach((operation) => {
+      transaction.getAllOperations().forEach((operation) => {
         expectedOperations.push(OperationMapper.toDBRow(operation));
       });
 
@@ -385,7 +380,7 @@ describe('TransactionRepository', () => {
 
       const expectedOperations: OperationDbRow[] = [];
 
-      transaction.getOperations().forEach((operation) => {
+      transaction.getAllOperations().forEach((operation) => {
         expectedOperations.push(OperationMapper.toDBRow(operation));
       });
 

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
@@ -3,13 +3,15 @@ import { OperationMapper } from 'src/application/mappers/operation.mapper';
 import { OperationDbRow, UserDbRow } from 'src/db/schema';
 import { TestDB } from 'src/db/test-db';
 import {
+  compareEntities,
   TransactionBuilder,
   TransactionBuilderResult,
 } from 'src/db/test-utils';
 import { Account, User } from 'src/domain';
-import { Amount, DateValue } from 'src/domain/domain-core';
+import { Amount, DateValue, Id } from 'src/domain/domain-core';
 import { OperationSnapshot } from 'src/domain/operations/types';
 import { TransactionBuildContext } from 'src/domain/transactions/types';
+import { ForeignKeyConstraintError } from 'src/presentation/errors';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -164,12 +166,71 @@ describe('TransactionRepository', () => {
       });
     });
 
-    it.todo(
-      'should restore all known operations and expose only active operations through getOperations',
-    );
+    it('should restore all known operations and expose only active operations through getOperations', async () => {
+      const transaction = data.transaction;
 
-    it.todo('should return null when transaction does not exist');
-    it.todo('should return null when transaction belongs to another user');
+      const allOperationsCount = transaction.getOperations().length;
+
+      const acc = transaction
+        .getOperations()
+        .reduce((acc, operation, index) => {
+          if (index % 2 === 0) {
+            operation.markAsDeleted();
+            acc++;
+          }
+          return acc;
+        }, 0);
+
+      await testDB.insertTransaction({
+        ...transaction.toSnapshot(),
+      });
+
+      const retrievedTransaction = await transactionRepository.getById(
+        user.id,
+        transaction.getId().valueOf(),
+      );
+
+      expect(retrievedTransaction).not.toBeNull();
+
+      const retrievedOperations = retrievedTransaction?.getOperations() ?? [];
+
+      expect(retrievedTransaction?.getAllOperations()).length(
+        allOperationsCount,
+      );
+
+      expect(retrievedOperations).length(allOperationsCount - acc);
+
+      retrievedOperations.forEach((operation) => {
+        expect(operation.isDeleted()).toBe(false);
+      });
+    });
+
+    it('should return null when transaction does not exist', async () => {
+      const retrievedTransaction = await transactionRepository.getById(
+        user.id,
+        Id.create().valueOf(),
+      );
+
+      expect(retrievedTransaction).toBeNull();
+    });
+
+    it('should return null when transaction belongs to another user', async () => {
+      const transaction = data.transaction;
+
+      await testDB.insertTransaction({
+        ...transaction.toSnapshot(),
+        isTombstone: true,
+      });
+
+      const anotherUser = await testDB.createUser();
+
+      const retrievedTransaction = await transactionRepository.getById(
+        anotherUser.id,
+        transaction.getId().valueOf(),
+      );
+
+      expect(retrievedTransaction).toBeNull();
+    });
 
     it('should not retrieve a tombstone transaction', async () => {
       const transaction = data.transaction;
@@ -189,7 +250,15 @@ describe('TransactionRepository', () => {
   });
 
   describe('create', () => {
-    it.todo('should not create a transaction when user does not exist');
+    it('should not create a transaction when user does not exist', async () => {
+      const transaction = data.transaction;
+
+      const nonExistentUserId = Id.create().valueOf();
+
+      await expect(
+        transactionRepository.create(nonExistentUserId, transaction),
+      ).rejects.toThrow(ForeignKeyConstraintError);
+    });
 
     it('should create a new transaction', async () => {
       const transaction = data.transaction;
@@ -326,7 +395,105 @@ describe('TransactionRepository', () => {
       );
     });
 
-    it.todo('should not update transaction belonging to another user');
+    it('should not update transaction belonging to another user', async () => {
+      const transaction = data.transaction;
+
+      const transactionSnapshot = transaction.toSnapshot();
+
+      const anotherUser = await testDB.createUser();
+
+      await testDB.insertTransaction(transaction.toSnapshot());
+
+      transaction.applyUpdate(
+        {
+          metadata: {
+            description: 'Updated description',
+            postingDate: transaction.getPostingDate().valueOf(),
+            transactionDate: transaction.getTransactionDate().valueOf(),
+          },
+        },
+        transactionContext,
+      );
+
+      await transactionRepository.update(anotherUser.id, transaction);
+
+      const retrievedTransaction = await transactionRepository.getById(
+        data.transaction.getUserId().valueOf(),
+        transaction.getId().valueOf(),
+      );
+
+      expect(retrievedTransaction).not.toBeNull();
+
+      if (!retrievedTransaction) {
+        throw new Error('Expected transaction to be retrieved');
+      }
+
+      compareEntities(transactionSnapshot, retrievedTransaction.toSnapshot());
+    });
+
+    it('should not pass already tombstone operations to operation repository save', async () => {
+      const transaction = data.transaction;
+      const transactionSnapshot = transaction.toSnapshot();
+      const [operationToDeleteOne, operationToDeleteTwo, ...activeOperations] =
+        transactionSnapshot.operations;
+      const operationsToDelete = [operationToDeleteOne, operationToDeleteTwo];
+
+      await testDB.insertTransaction({
+        ...transactionSnapshot,
+        operations: [
+          ...operationsToDelete.map((operation) => ({
+            ...operation,
+            isTombstone: true,
+          })),
+          ...activeOperations,
+        ],
+      });
+
+      const restoredTransaction = await transactionRepository.getById(
+        user.id,
+        transaction.getId().valueOf(),
+      );
+
+      expect(restoredTransaction).not.toBeNull();
+
+      if (!restoredTransaction) {
+        throw new Error('Expected transaction to be restored');
+      }
+
+      restoredTransaction.applyUpdate({
+        metadata: {
+          description: 'Updated description',
+          postingDate: restoredTransaction.getPostingDate().valueOf(),
+          transactionDate: restoredTransaction.getTransactionDate().valueOf(),
+        },
+      });
+
+      await transactionRepository.update(user.id, restoredTransaction);
+
+      const expectedOperationsSnapshots = new Map<UUID, OperationSnapshot>();
+
+      const persistedTransaction = await testDB.getTransactionWithRelations(
+        transaction.getId().valueOf(),
+      );
+
+      persistedTransaction?.operations.forEach((operationSnapshot) => {
+        expectedOperationsSnapshots.set(
+          operationSnapshot.id,
+          operationSnapshot,
+        );
+      });
+
+      const expectedOperations = restoredTransaction
+        .getAllOperations()
+        .filter((operation) => !operation.isDeleted())
+        .map((operation) => OperationMapper.toDBRow(operation));
+
+      expect(mockOperationsRepository.save).toHaveBeenCalledWith(
+        user.id,
+        expectedOperations,
+        expectedOperationsSnapshots,
+      );
+    });
 
     it('should not update isTombstone field when saving', async () => {
       const transaction = data.transaction;
@@ -348,7 +515,31 @@ describe('TransactionRepository', () => {
   });
 
   describe('softDelete', () => {
-    it.todo('should not soft delete a transaction belonging to another user');
+    it('should not soft delete a transaction belonging to another user', async () => {
+      const transaction = data.transaction;
+
+      const anotherUser = await testDB.createUser();
+
+      await testDB.insertTransaction(transaction.toSnapshot());
+
+      await transactionRepository.softDelete(anotherUser.id, transaction);
+
+      const retrievedTransaction = await transactionRepository.getById(
+        data.transaction.getUserId().valueOf(),
+        transaction.getId().valueOf(),
+      );
+
+      expect(retrievedTransaction).not.toBeNull();
+
+      if (!retrievedTransaction) {
+        throw new Error('Expected transaction to be retrieved');
+      }
+
+      compareEntities(
+        transaction.toSnapshot(),
+        retrievedTransaction.toSnapshot(),
+      );
+    });
 
     it('should soft delete the transaction and its operations', async () => {
       const transaction = data.transaction;

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.test.ts
@@ -11,6 +11,7 @@ import { Account, User } from 'src/domain';
 import { Amount, DateValue, Id } from 'src/domain/domain-core';
 import { OperationSnapshot } from 'src/domain/operations/types';
 import { TransactionBuildContext } from 'src/domain/transactions/types';
+import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
 import { ForeignKeyConstraintError } from 'src/presentation/errors';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -194,11 +195,11 @@ describe('TransactionRepository', () => {
 
       const retrievedOperations = retrievedTransaction?.getOperations() ?? [];
 
-      expect(retrievedTransaction?.getAllOperations()).length(
+      expect(retrievedTransaction?.getAllOperations()).toHaveLength(
         allOperationsCount,
       );
 
-      expect(retrievedOperations).length(allOperationsCount - acc);
+      expect(retrievedOperations).toHaveLength(allOperationsCount - acc);
 
       retrievedOperations.forEach((operation) => {
         expect(operation.isDeleted()).toBe(false);
@@ -219,7 +220,6 @@ describe('TransactionRepository', () => {
 
       await testDB.insertTransaction({
         ...transaction.toSnapshot(),
-        isTombstone: true,
       });
 
       const anotherUser = await testDB.createUser();
@@ -283,7 +283,7 @@ describe('TransactionRepository', () => {
 
       const expectedSnapshots = transaction
         .getAllOperations()
-        .map((op) => op.toSnapshot());
+        .map((op) => OperationMapper.toDBRow(op));
 
       expect(mockOperationsRepository.save).toHaveBeenCalledWith(
         user.id,
@@ -415,7 +415,9 @@ describe('TransactionRepository', () => {
         transactionContext,
       );
 
-      await transactionRepository.update(anotherUser.id, transaction);
+      await expect(
+        transactionRepository.update(anotherUser.id, transaction),
+      ).rejects.toThrow(RepositoryInvariantError);
 
       const retrievedTransaction = await transactionRepository.getById(
         data.transaction.getUserId().valueOf(),
@@ -423,12 +425,7 @@ describe('TransactionRepository', () => {
       );
 
       expect(retrievedTransaction).not.toBeNull();
-
-      if (!retrievedTransaction) {
-        throw new Error('Expected transaction to be retrieved');
-      }
-
-      compareEntities(transactionSnapshot, retrievedTransaction.toSnapshot());
+      compareEntities(transactionSnapshot, retrievedTransaction!.toSnapshot());
     });
 
     it('should not pass already tombstone operations to operation repository save', async () => {
@@ -522,7 +519,9 @@ describe('TransactionRepository', () => {
 
       await testDB.insertTransaction(transaction.toSnapshot());
 
-      await transactionRepository.softDelete(anotherUser.id, transaction);
+      await expect(
+        transactionRepository.softDelete(anotherUser.id, transaction),
+      ).rejects.toThrow(RepositoryInvariantError);
 
       const retrievedTransaction = await transactionRepository.getById(
         data.transaction.getUserId().valueOf(),

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
@@ -108,9 +108,15 @@ export class TransactionRepository
       operationsSnapshots.set(operationSnapshot.id, operationSnapshot);
     });
 
+    const operationsToSave = operations.filter((operation) => {
+      const operationSnapshot = operationsSnapshots.get(operation.id);
+
+      return !(operationSnapshot?.isTombstone && operation.isTombstone);
+    });
+
     await this.operationsRepository.save(
       userId,
-      operations,
+      operationsToSave,
       operationsSnapshots,
     );
   }

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
@@ -13,7 +13,10 @@ import {
 } from 'src/db/schema';
 import { Transaction } from 'src/domain';
 import { OperationSnapshot } from 'src/domain/operations/types';
-import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
+import {
+  RepositoryInvariantError,
+  RepositoryNotFoundError,
+} from 'src/infrastructure/infrastructure.errors';
 
 import { BaseRepository } from '../BaseRepository';
 
@@ -104,7 +107,7 @@ export class TransactionRepository
     );
 
     if (!snapshot) {
-      throw new RepositoryInvariantError(
+      throw new RepositoryNotFoundError(
         `Transaction ${transaction.getId().valueOf()} snapshot not found for user ${userId}`,
       );
     }

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/db/schema';
 import { Transaction } from 'src/domain';
 import { OperationSnapshot } from 'src/domain/operations/types';
+import { RepositoryInvariantError } from 'src/infrastructure/infrastructure.errors';
 
 import { BaseRepository } from '../BaseRepository';
 
@@ -102,9 +103,15 @@ export class TransactionRepository
       transaction.getId().valueOf(),
     );
 
+    if (!snapshot) {
+      throw new RepositoryInvariantError(
+        `Transaction ${transaction.getId().valueOf()} snapshot not found for user ${userId}`,
+      );
+    }
+
     const operationsSnapshots = new Map<UUID, OperationSnapshot>();
 
-    snapshot?.operations.forEach((operationSnapshot) => {
+    snapshot.operations.forEach((operationSnapshot) => {
       operationsSnapshots.set(operationSnapshot.id, operationSnapshot);
     });
 

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
@@ -93,7 +93,7 @@ export class TransactionRepository
   ): Promise<void> {
     const operations: OperationDbRow[] = [];
 
-    transaction.getOperations().forEach((operation) => {
+    transaction.getAllOperations().forEach((operation) => {
       operations.push(OperationMapper.toDBRow(operation));
     });
 
@@ -198,7 +198,7 @@ export class TransactionRepository
     await this.executeDatabaseOperation(
       async () => {
         const operationsDataToInsert = transaction
-          .getOperations()
+          .getAllOperations()
           .map((operation) => OperationMapper.toDBRow(operation));
 
         await this.insertTransactionRow(userId, transaction);

--- a/apps/backend/src/infrastructure/infrastructure.errors.ts
+++ b/apps/backend/src/infrastructure/infrastructure.errors.ts
@@ -28,3 +28,12 @@ export class ForbiddenAccessError extends InfrastructureError {
     super(message);
   }
 }
+
+/**
+ * Thrown when repository input violates expected persistence invariants.
+ */
+export class RepositoryInvariantError extends InfrastructureError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -21,6 +21,10 @@ import { Amount, Currency, DateValue, Id } from 'src/domain/domain-core';
 import { createServer } from 'src/presentation/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+const parseResponse = <T>(response: { body: string }): T => {
+  return JSON.parse(response.body) as T;
+};
+
 const testUser = {
   email: 'test@example.com',
   name: 'Test User',
@@ -108,7 +112,7 @@ describe('Transactions Integration Tests', () => {
         url,
       });
 
-      const transaction = JSON.parse(response.body) as TransactionResponseDTO;
+      const transaction = parseResponse<TransactionResponseDTO>(response);
 
       expect(response.statusCode).toBe(201);
 
@@ -382,7 +386,19 @@ describe('Transactions Integration Tests', () => {
       });
     });
 
-    it.todo('should return 404 when transaction is soft-deleted (tombstone)');
+    it('should return 404 when transaction is soft-deleted (tombstone)', async () => {
+      await testDB.softDeleteTransaction(transaction.id);
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url: `${url}/${transaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
 
     it('should not return soft-deleted (tombstone) operations', async () => {
       const createdTransaction = await testDB.createTransaction(userId);
@@ -492,12 +508,22 @@ describe('Transactions Integration Tests', () => {
       expect(response.statusCode).toBe(404);
     });
 
-    it.todo('should return 401 when not authorized');
+    it('should return 401 when not authorized', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: `${url}/some-transaction-id`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
   });
 
   describe('GET /api/transactions', () => {
-    it('should retrieve all transactions for the user', async () => {
-      const accounts = await Promise.all([
+    // TODO: consider moving accounts to the top-level describe block if they are needed across multiple test cases
+    let accounts: AccountDbRow[];
+
+    beforeEach(async () => {
+      accounts = await Promise.all([
         testDB.createAccount(userId, {
           currency: Currency.create('USD').valueOf(),
           name: 'Checking USD',
@@ -511,7 +537,9 @@ describe('Transactions Integration Tests', () => {
           name: 'Savings EUR',
         }),
       ]);
+    });
 
+    it('should retrieve all transactions for the user', async () => {
       const transaction1Params: CreateTransactionProps = {
         currencyCode: accounts[0].currency,
         description: 'transaction one',
@@ -557,13 +585,151 @@ describe('Transactions Integration Tests', () => {
       expect(userTransactions).toHaveLength(transactionData.length);
     });
 
-    it.todo('should return 401 when not authorized');
-    it.todo('should return empty array when user has no transactions');
-    it.todo('should not return soft-deleted (tombstone) transactions');
-    it.todo(
-      'should not return soft-deleted (tombstone) operations in transactions',
-    );
+    it('should return 401 when not authorized', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: `${url}/some-transaction-id`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should return empty array when user has no transactions', async () => {
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const transactions = parseResponse<TransactionResponseDTO[]>(response);
+
+      expect(transactions).toHaveLength(0);
+    });
+
+    it('should not return soft-deleted (tombstone) transactions', async () => {
+      const transactionToBeDeleted = await testDB.createTransaction(userId);
+
+      const otherTransaction = await testDB.createTransaction(userId);
+
+      await testDB.softDeleteTransaction(transactionToBeDeleted.id);
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const transactions = parseResponse<TransactionResponseDTO[]>(response);
+
+      const deletedTransaction = transactions.find(
+        (tx) => tx.id === transactionToBeDeleted.id,
+      );
+
+      expect(deletedTransaction).toBeUndefined();
+
+      const otherTransactionExists = transactions.find(
+        (tx) => tx.id === otherTransaction.id,
+      );
+
+      expect(otherTransactionExists).toBeDefined();
+    });
+
+    it('should not return soft-deleted (tombstone) operations in transactions', async () => {
+      const createdTransaction = await testDB.createTransaction(userId);
+
+      const deletedOperationsData = [
+        {
+          accountId: accounts[0].id,
+          amount: Amount.create('-50').valueOf(),
+          description: 'Deleted operation',
+          id: Id.create().valueOf(),
+          isTombstone: true,
+          transactionId: createdTransaction.id,
+          value: Amount.create('-50').valueOf(),
+        },
+        {
+          accountId: accounts[1].id,
+          amount: Amount.create('50').valueOf(),
+          description: 'Deleted operation',
+          id: Id.create().valueOf(),
+          isTombstone: true,
+          transactionId: createdTransaction.id,
+          value: Amount.create('50').valueOf(),
+        },
+      ];
+
+      const activeOperations = [
+        {
+          accountId: accounts[0].id,
+          amount: Amount.create('-50').valueOf(),
+          description: 'Active operation',
+          id: Id.create().valueOf(),
+          transactionId: createdTransaction.id,
+          value: Amount.create('-50').valueOf(),
+        },
+        {
+          accountId: accounts[1].id,
+          amount: Amount.create('50').valueOf(),
+          description: 'Active operation',
+          id: Id.create().valueOf(),
+          transactionId: createdTransaction.id,
+          value: Amount.create('50').valueOf(),
+        },
+      ];
+
+      const operationsData = [...deletedOperationsData, ...activeOperations];
+
+      await Promise.all(
+        operationsData.map((op) => testDB.createOperation(userId, op)),
+      );
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const transactions = parseResponse<TransactionResponseDTO[]>(response);
+
+      const transactionResponse = transactions.find(
+        (tx) => tx.id === createdTransaction.id,
+      );
+
+      expect(transactionResponse).toBeDefined();
+
+      transactionResponse!.operations.forEach((op) => {
+        const isDeleted = deletedOperationsData.some(
+          (deletedOp) => deletedOp.id === op.id,
+        );
+
+        expect(isDeleted).toBe(false);
+
+        const matchedOp = activeOperations.find((o) => o.id === op.id);
+
+        if (!matchedOp) {
+          throw new Error(
+            `Operation with ID ${op.id} not found in active operations`,
+          );
+        }
+
+        compareCommonEntities(matchedOp, op as typeof matchedOp);
+      });
+    });
+
     it.todo('should return transactions filtered by accountId query param');
+
     it.todo('should return 400 for invalid accountId query param (non-UUID)');
   });
 
@@ -932,11 +1098,136 @@ describe('Transactions Integration Tests', () => {
         compareCommonEntities(originalOp, op);
       });
     });
-    it.todo('should return 404 when updating a non-existent transaction');
-    it.todo('should return 404 when updating a soft-deleted transaction');
-    it.todo("should return 404 when updating another user's transaction");
-    it.todo('should return 400 for invalid payload (missing required fields)');
-    it.todo('should return 401 when not authorized');
+
+    it('should return 404 when updating a non-existent transaction', async () => {
+      const nonExistentId = Id.create().valueOf();
+
+      const updatedData: UpdateTransactionRequestDTO = {
+        description: 'Updated description',
+        operations: {
+          create: [],
+          delete: [],
+          update: [],
+        },
+        postingDate: DateValue.create().valueOf(),
+        transactionDate: DateValue.create().valueOf(),
+      };
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'PUT',
+        payload: updatedData,
+        url: `${url}/${nonExistentId}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 404 when updating a soft-deleted transaction', async () => {
+      const transaction = await testDB.createTransaction(userId);
+
+      await testDB.softDeleteTransaction(transaction.id);
+
+      const updatedData: UpdateTransactionRequestDTO = {
+        description: 'Updated description',
+        operations: {
+          create: [],
+          delete: [],
+          update: [],
+        },
+        postingDate: DateValue.create().valueOf(),
+        transactionDate: DateValue.create().valueOf(),
+      };
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'PUT',
+        payload: updatedData,
+        url: `${url}/${transaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("should return 404 when updating another user's transaction", async () => {
+      const another = await testDB.createUser();
+      const transaction = await testDB.createTransaction(another.id);
+
+      const updatedData: UpdateTransactionRequestDTO = {
+        description: 'Updated description',
+        operations: {
+          create: [],
+          delete: [],
+          update: [],
+        },
+        postingDate: DateValue.create().valueOf(),
+        transactionDate: DateValue.create().valueOf(),
+      };
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'PUT',
+        payload: updatedData,
+        url: `${url}/${transaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('should return 400 for invalid payload (missing required fields)', async () => {
+      const transaction = await testDB.createTransactionWithOperations(userId);
+
+      const invalidPayload = {
+        description: 'Updated description',
+        operations: {
+          create: [],
+          delete: [],
+          update: [],
+        },
+        // Missing postingDate and transactionDate
+      };
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'PUT',
+        payload: invalidPayload,
+        url: `${url}/${transaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 401 when not authorized', async () => {
+      const transaction = await testDB.createTransactionWithOperations(userId);
+
+      const updatedData: UpdateTransactionRequestDTO = {
+        description: 'Updated description',
+        operations: {
+          create: [],
+          delete: [],
+          update: [],
+        },
+        postingDate: DateValue.create().valueOf(),
+        transactionDate: DateValue.create().valueOf(),
+      };
+
+      const response = await server.inject({
+        method: 'PUT',
+        payload: updatedData,
+        url: `${url}/${transaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
     it.todo('should return 409 on optimistic locking conflict (stale version)');
 
     it('should return 400 when resulting operations are unbalanced (sum != 0)', async () => {

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -64,6 +64,23 @@ describe('Transactions Integration Tests', () => {
     await testDB.cleanupTestDb();
   });
 
+  const createAccounts = async () => {
+    return Promise.all([
+      testDB.createAccount(userId, {
+        currency: Currency.create('USD').valueOf(),
+        name: 'Checking USD',
+      }),
+      testDB.createAccount(userId, {
+        currency: Currency.create('USD').valueOf(),
+        name: 'Savings USD',
+      }),
+      testDB.createAccount(userId, {
+        currency: Currency.create('EUR').valueOf(),
+        name: 'Savings EUR',
+      }),
+    ]);
+  };
+
   describe('POST /api/transactions', () => {
     let account1: AccountDbRow;
     let account2: AccountDbRow;
@@ -71,13 +88,7 @@ describe('Transactions Integration Tests', () => {
     let operation2: OperationCreateInput;
 
     beforeEach(async () => {
-      account1 = await testDB.createAccount(userId, {
-        name: 'Checking',
-      });
-
-      account2 = await testDB.createAccount(userId, {
-        name: 'Savings',
-      });
+      [account1, account2] = await createAccounts();
 
       operation1 = {
         accountId: account1.id,
@@ -290,20 +301,7 @@ describe('Transactions Integration Tests', () => {
     const operationsMap = new Map<UUID, OperationDbRow>();
 
     beforeEach(async () => {
-      const accounts = await Promise.all([
-        testDB.createAccount(userId, {
-          currency: Currency.create('USD').valueOf(),
-          name: 'Checking USD',
-        }),
-        testDB.createAccount(userId, {
-          currency: Currency.create('USD').valueOf(),
-          name: 'Savings USD',
-        }),
-        testDB.createAccount(userId, {
-          currency: Currency.create('EUR').valueOf(),
-          name: 'Savings EUR',
-        }),
-      ]);
+      const accounts = await createAccounts();
 
       transaction = await testDB.createTransaction(userId);
 
@@ -519,24 +517,10 @@ describe('Transactions Integration Tests', () => {
   });
 
   describe('GET /api/transactions', () => {
-    // TODO: consider moving accounts to the top-level describe block if they are needed across multiple test cases
     let accounts: AccountDbRow[];
 
     beforeEach(async () => {
-      accounts = await Promise.all([
-        testDB.createAccount(userId, {
-          currency: Currency.create('USD').valueOf(),
-          name: 'Checking USD',
-        }),
-        testDB.createAccount(userId, {
-          currency: Currency.create('USD').valueOf(),
-          name: 'Savings USD',
-        }),
-        testDB.createAccount(userId, {
-          currency: Currency.create('EUR').valueOf(),
-          name: 'Savings EUR',
-        }),
-      ]);
+      accounts = await createAccounts();
     });
 
     it('should retrieve all transactions for the user', async () => {
@@ -846,13 +830,7 @@ describe('Transactions Integration Tests', () => {
     let operation2Data: OperationCreateInput;
 
     beforeEach(async () => {
-      account1Data = await testDB.createAccount(userId, {
-        name: 'Checking',
-      });
-
-      account2Data = await testDB.createAccount(userId, {
-        name: 'Savings',
-      });
+      [account1Data, account2Data] = await createAccounts();
 
       operation1Data = {
         accountId: account1Data.id,

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -572,7 +572,7 @@ describe('Transactions Integration Tests', () => {
     it('should return 401 when not authorized', async () => {
       const response = await server.inject({
         method: 'GET',
-        url: `${url}/some-transaction-id`,
+        url: `${url}`,
       });
 
       expect(response.statusCode).toBe(401);

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -363,6 +363,7 @@ describe('Transactions Integration Tests', () => {
 
     it.todo('should return 404 for a non-existent transaction ID');
     it.todo('should return 404 when transaction is soft-deleted (tombstone)');
+    it.todo('should not return soft-deleted (tombstone) operations');
     it.todo("should return 404 when accessing another user's transaction");
     it.todo('should return 401 when not authorized');
   });
@@ -432,6 +433,9 @@ describe('Transactions Integration Tests', () => {
     it.todo('should return 401 when not authorized');
     it.todo('should return empty array when user has no transactions');
     it.todo('should not return soft-deleted (tombstone) transactions');
+    it.todo(
+      'should not return soft-deleted (tombstone) operations in transactions',
+    );
     it.todo('should return transactions filtered by accountId query param');
     it.todo('should return 400 for invalid accountId query param (non-UUID)');
   });

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -361,10 +361,137 @@ describe('Transactions Integration Tests', () => {
       });
     });
 
-    it.todo('should return 404 for a non-existent transaction ID');
+    it('should return 404 for a non-existent transaction ID', async () => {
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url: `${url}/${Id.create().valueOf()}`,
+      });
+
+      const body = JSON.parse(response.body) as {
+        error: boolean;
+        message: string;
+      };
+
+      expect(response.statusCode).toBe(404);
+      expect(body).toEqual({
+        error: true,
+        message: 'Transaction not found',
+      });
+    });
+
     it.todo('should return 404 when transaction is soft-deleted (tombstone)');
-    it.todo('should not return soft-deleted (tombstone) operations');
-    it.todo("should return 404 when accessing another user's transaction");
+
+    it('should not return soft-deleted (tombstone) operations', async () => {
+      const createdTransaction = await testDB.createTransaction(userId);
+
+      const deletedOperationsData = [
+        {
+          accountId: operations[0].accountId,
+          amount: Amount.create('-50').valueOf(),
+          description: 'Deleted operation',
+          id: Id.create().valueOf(),
+          isTombstone: true,
+          transactionId: createdTransaction.id,
+          value: Amount.create('-50').valueOf(),
+        },
+        {
+          accountId: operations[1].accountId,
+          amount: Amount.create('50').valueOf(),
+          description: 'Deleted operation',
+          id: Id.create().valueOf(),
+          isTombstone: true,
+          transactionId: createdTransaction.id,
+          value: Amount.create('50').valueOf(),
+        },
+      ];
+
+      const activeOperations = [
+        {
+          accountId: operations[0].accountId,
+          amount: Amount.create('-50').valueOf(),
+          description: 'Active operation',
+          id: Id.create().valueOf(),
+          transactionId: createdTransaction.id,
+          value: Amount.create('-50').valueOf(),
+        },
+        {
+          accountId: operations[1].accountId,
+          amount: Amount.create('50').valueOf(),
+          description: 'Active operation',
+          id: Id.create().valueOf(),
+          transactionId: createdTransaction.id,
+          value: Amount.create('50').valueOf(),
+        },
+      ];
+
+      const operationsData = [...deletedOperationsData, ...activeOperations];
+
+      await Promise.all(
+        operationsData.map((op) => testDB.createOperation(userId, op)),
+      );
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url: `${url}/${createdTransaction.id}`,
+      });
+
+      const transactionResponse = JSON.parse(
+        response.body,
+      ) as TransactionResponseDTO;
+
+      expect(response.statusCode).toBe(200);
+
+      expect(transactionResponse.operations).toHaveLength(
+        activeOperations.length,
+      );
+
+      deletedOperationsData.forEach((deletedOp) => {
+        expect(
+          transactionResponse.operations.some((op) => op.id === deletedOp.id),
+        ).toBe(false);
+      });
+
+      transactionResponse.operations.forEach((op) => {
+        const isDeleted = deletedOperationsData.some(
+          (deletedOp) => deletedOp.id === op.id,
+        );
+
+        expect(isDeleted).toBe(false);
+
+        const matchedOp = activeOperations.find((o) => o.id === op.id);
+
+        if (!matchedOp) {
+          throw new Error(
+            `Operation with ID ${op.id} not found in active operations`,
+          );
+        }
+
+        compareCommonEntities(matchedOp, op as typeof matchedOp);
+      });
+    });
+
+    it("should return 404 when accessing another user's transaction", async () => {
+      const otherUser = await testDB.createUser();
+
+      const otherUserTransaction = await testDB.createTransaction(otherUser.id);
+
+      const response = await server.inject({
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+        method: 'GET',
+        url: `${url}/${otherUserTransaction.id}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
     it.todo('should return 401 when not authorized');
   });
 

--- a/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
+++ b/apps/backend/src/interfaces/transactions/transaction.integration.test.ts
@@ -74,10 +74,6 @@ describe('Transactions Integration Tests', () => {
         currency: Currency.create('USD').valueOf(),
         name: 'Savings USD',
       }),
-      testDB.createAccount(userId, {
-        currency: Currency.create('EUR').valueOf(),
-        name: 'Savings EUR',
-      }),
     ]);
   };
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -29,7 +29,8 @@ Represents a single financial posting affecting an account.
 - `value` — signed integer in the **transaction's currency** (cents); used for balance validation
 - For same-currency transactions `amount === value`
 - Positive = debit, Negative = credit
-- May be soft-deleted in persistence via `isTombstone`, but tombstone operations are currently excluded from the active domain and read contract
+- May be soft-deleted in persistence via `isTombstone`
+- Tombstone operations remain part of the raw transaction aggregate state for persistence, but are excluded from active domain accessors and read API responses
 - Has optional description field
 - `isSystem` — reserved for future trading operations (see below)
 
@@ -86,11 +87,12 @@ Represents different monetary units used in the system.
 1. Transactions use soft delete via `isTombstone`
 2. Tombstone transactions must not appear in normal read API responses
 3. Operations may also be marked with `isTombstone` in persistence
-4. Tombstone operations are currently treated as archived storage rows only:
-   - they are not part of the active aggregate contract
-   - they are not returned to clients
-   - they are ignored by normal read flows
-5. If deleted operations later need audit/history/restore semantics, the aggregate and repository contracts must be expanded explicitly
+4. Transaction repositories restore the full raw aggregate state, including tombstone operations
+5. The `Transaction` aggregate separates raw and active operation access:
+   - `getAllOperations()` returns all known operations for persistence
+   - `getOperations()` returns active operations only for domain logic
+   - tombstone operations are not returned to clients and are ignored by normal read flows
+6. Tombstone operations cannot be updated after they are restored into the aggregate
 
 ## Examples
 
@@ -196,7 +198,7 @@ Settings
 - **Timestamps**: ISO datetime strings with branded types (`IsoDatetimeString`)
 - **IDs**: UUIDs for all entities
 - **Soft deletion**: Uses `isTombstone` flag instead of hard deletes
-- **MVP operation deletion rule**: deleted operations may remain in storage but are excluded from active domain/read behavior
+- **MVP operation deletion rule**: deleted operations may remain in raw aggregate and storage state, but are excluded from active domain/read behavior
 - **System entities**: System accounts and operations marked with `isSystem = true`
 
 ## Future Improvements
@@ -242,7 +244,8 @@ Settings
    - Idempotent operations (return `undefined` instead of throwing errors)
    - User ownership checks in service layer
    - Read-side returns active data only
-   - MVP write-side does not expose tombstone operations as part of the aggregate contract
+   - Write-side repositories restore and persist raw aggregate state, including tombstone operations
+   - Domain business accessors expose active operations by default
 6. **Type safety**:
    - Branded types for dates (`IsoDatetimeString`)
    - Planned branded types for `Money` and `CurrencyCode`


### PR DESCRIPTION
## What changed

- Restore all operations into the `Transaction` aggregate, including tombstone operations.
- Keep `getOperations()` as the active-only accessor.
- Add `getAllOperations()` for persistence/raw state.
- Update `TransactionRepository` to persist all known operations instead of active-only operations.
- Update domain and repository tests to lock in the active/raw split.

## Why

`LED-31` requires the domain model to clearly separate active operations from raw operations. Repository reads should restore the complete aggregate state, while domain/client-facing accessors should hide tombstone operations by default.

## Validation

- `pnpm --filter backend test -- src/domain/transactions/transaction.entity.test.ts src/infrastructure/db/transaction/transaction.repository.test.ts src/infrastructure/db/operations/operation.repository.test.ts`
- `pnpm --filter backend ts-check`
- `pnpm --filter backend lint`