### PR TITLE
LED-37: Transaction repository boundaries

### DIFF
--- a/.agents/skills/ledgerly-architecture-docs/SKILL.md
+++ b/.agents/skills/ledgerly-architecture-docs/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: ledgerly-architecture-docs
+description: Maintain ADRs and related architecture documentation in Ledgerly. Use when creating, updating, superseding, archiving, or linking architecture decisions, plan docs, RFC-like notes, and decision logs.
+---
+
+# Ledgerly Architecture Docs
+
+Use this skill to keep architecture knowledge consistent across ADRs, task plans,
+and related documentation. Prefer small, precise edits and stable references.
+
+## Scope
+
+Use this skill when the user asks to:
+
+- create or update ADRs;
+- add architectural decision rationale to task docs;
+- link Jira/PR to architecture docs;
+- archive completed plan documents;
+- replace obsolete decisions and mark superseded status.
+
+Do not use this skill for runtime bug fixing, feature coding, or non-document
+changes unless explicitly requested.
+
+## Source of Truth
+
+- ADR index and records: `docs/architecture/adr/`
+- Active implementation plans: `docs/plans/`
+- Archived plans and analysis: `docs/archive/`
+- Issue tracker references: Jira links in plan/ADR metadata
+- Code truth for validation: current codebase and tests
+
+When documentation conflicts with code, verify code first and then update docs.
+
+## File Conventions
+
+### ADR location and naming
+
+- Directory: `docs/architecture/adr/`
+- Index file: `docs/architecture/adr/README.md`
+- ADR filename: `NNNN-short-kebab-case-title.md`
+- Numbering: increment monotonically; never renumber old ADRs.
+
+### ADR metadata
+
+Every ADR should include:
+
+- `Status: Proposed|Accepted|Superseded|Deprecated`
+- `Date: YYYY-MM-DD`
+- `Jira: <link-or-N/A>`
+- `PR: <link-or-TBD>`
+
+### Minimum ADR sections
+
+1. `Context`
+2. `Decision`
+3. `Alternatives Considered`
+4. `Consequences`
+5. `Related`
+
+Keep each section concise and decision-focused.
+
+## Editing Rules
+
+1. One decision per ADR.
+2. Avoid repeating implementation-level details better suited for plan docs.
+3. Preserve historical facts; do not rewrite accepted history to match new intent.
+4. If direction changed, create new ADR and mark old one as `Superseded`.
+5. Keep links stable; when moving plan docs to archive, update ADR links.
+6. Prefer explicit links to Jira issue and PR once available.
+
+## Plan Doc Workflow
+
+For task documents in `docs/plans/`:
+
+1. Keep checkboxes as the execution tracker during implementation.
+2. On completion, ensure status reflects done state.
+3. If project convention is to archive completed plans, move to
+   `docs/archive/plans/` preserving git history.
+4. After move, update all references from ADR and other docs.
+
+## Lifecycle Playbooks
+
+### Create ADR for a completed architectural decision
+
+1. Find latest ADR number from `docs/architecture/adr/`.
+2. Create `NNNN-*.md` with required metadata and sections.
+3. Add concise rationale and rejected alternatives.
+4. Update ADR index in `docs/architecture/adr/README.md`.
+5. Add Jira immediately; fill PR as `TBD` if not created.
+6. After PR creation, replace `PR: TBD` with actual link.
+
+### Supersede an ADR
+
+1. Create a new ADR with the next number and updated decision.
+2. In old ADR, set status to `Superseded`.
+3. In old ADR `Related`, link the new ADR.
+4. In new ADR `Related`, link the superseded ADR.
+5. Update ADR index statuses if listed.
+
+### Finalize completed task docs
+
+1. Verify all checklist items are complete.
+2. Add/verify Jira and PR references.
+3. Move completed plan to archive if team follows archive policy.
+4. Update links in ADR and any docs that referenced old path.
+
+## Quality Checklist
+
+Before finalizing documentation changes, confirm:
+
+- metadata fields exist and are accurate;
+- status values are valid;
+- links are not stale after moves;
+- ADR index includes new ADR;
+- no contradictory statements versus code and tests;
+- language is concise and future-readable.
+
+## Templates
+
+### ADR template
+
+```md
+# ADR NNNN: Title
+
+- Status: Proposed|Accepted|Superseded|Deprecated
+- Date: YYYY-MM-DD
+- Jira: <link-or-N/A>
+- PR: <link-or-TBD>
+
+## Context
+
+## Decision
+
+## Alternatives Considered
+
+1. Option A
+
+- Pros
+- Cons
+
+2. Option B
+
+- Pros
+- Cons
+
+## Consequences
+
+## Related
+```
+
+### Plan completion note snippet
+
+```md
+Статус документа: выполнено.
+
+- [x] Связать этот документ с Jira-задачей и итоговым pull request.
+      Jira: <link>
+      PR: <link>
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -188,3 +188,18 @@ When creating transactions across currencies:
 - ❌ Business logic in controllers or repositories
 - ❌ Skipping `transactionManager.run()` for multi-repo operations
 - ❌ Using interfaces instead of types (ESLint enforces this)
+
+## Documentation Workflow
+
+For architecture documentation tasks, use the custom skill
+`ledgerly-architecture-docs` from `.agents/skills/ledgerly-architecture-docs/SKILL.md`.
+
+Use it when asked to:
+
+- create or update ADR files;
+- supersede/deprecate old architecture decisions;
+- move completed plan documents to archive;
+- sync Jira/PR links between plan docs and ADRs.
+
+For Jira board task discovery and ordering, continue to use
+`ledgerly-jira-board`.

--- a/apps/backend/src/application/index.ts
+++ b/apps/backend/src/application/index.ts
@@ -3,4 +3,5 @@ export * from './usecases';
 export * from './interfaces';
 export * from './dto';
 export * from './mappers';
+export * from './read-models';
 export * from './application.errors';

--- a/apps/backend/src/application/interfaces/TransactionQueryRepository.interface.ts
+++ b/apps/backend/src/application/interfaces/TransactionQueryRepository.interface.ts
@@ -1,5 +1,6 @@
 import { TransactionQueryParams, UUID } from '@ledgerly/shared/types';
-import { TransactionWithRelations } from 'src/db/schema';
+
+import { TransactionReadModel } from '../read-models';
 
 export type PaginatedResult<T> = {
   items: T[];
@@ -8,7 +9,7 @@ export type PaginatedResult<T> = {
 
 /**
  * Query repository for read-only transaction operations.
- * Returns DTOs optimized for display without full domain model restoration.
+ * Returns application read models without restoring domain aggregates.
  */
 export type TransactionQueryRepositoryInterface = {
   /**
@@ -17,7 +18,7 @@ export type TransactionQueryRepositoryInterface = {
   findById(
     userId: UUID,
     transactionId: UUID,
-  ): Promise<TransactionWithRelations | null>;
+  ): Promise<TransactionReadModel | null>;
 
   /**
    * Find all transactions with optional filtering
@@ -25,5 +26,5 @@ export type TransactionQueryRepositoryInterface = {
   findAll(
     userId: UUID,
     query: TransactionQueryParams,
-  ): Promise<PaginatedResult<TransactionWithRelations>>;
+  ): Promise<PaginatedResult<TransactionReadModel>>;
 };

--- a/apps/backend/src/application/interfaces/TransactionRepository.interface.ts
+++ b/apps/backend/src/application/interfaces/TransactionRepository.interface.ts
@@ -2,12 +2,13 @@ import { UUID } from '@ledgerly/shared/types';
 import { Transaction } from 'src/domain';
 import { Version } from 'src/domain/domain-core';
 
-import { OperationRepositoryInterface } from './OperationRepository.interface';
-
 export type TransactionUpdateResult =
   | { ok: true }
   | { ok: false; reason: 'NOT_FOUND' | 'VERSION_CONFLICT' };
 
+/**
+ * Write-side repository for persisting and restoring Transaction aggregates.
+ */
 export type TransactionRepositoryInterface = {
   update(
     userId: UUID,
@@ -17,5 +18,4 @@ export type TransactionRepositoryInterface = {
   create(userId: UUID, transaction: Transaction): Promise<void>;
   getById(userId: UUID, transactionId: UUID): Promise<Transaction | null>;
   softDelete(userId: UUID, transaction: Transaction): Promise<void>;
-  readonly operationsRepository: OperationRepositoryInterface;
 };

--- a/apps/backend/src/application/mappers/index.ts
+++ b/apps/backend/src/application/mappers/index.ts
@@ -1,3 +1,3 @@
 export { OperationMapper } from './operation.mapper';
+export { TransactionReadModelResponseMapper } from './transaction-read-model-response.mapper';
 export { TransactionMapper } from './transaction.mapper';
-export { TransactionViewMapper } from './transaction-view.mapper';

--- a/apps/backend/src/application/mappers/transaction-read-model-response.mapper.ts
+++ b/apps/backend/src/application/mappers/transaction-read-model-response.mapper.ts
@@ -1,8 +1,10 @@
 import { OperationResponseDTO, TransactionResponseDTO } from '../dto';
 import { OperationReadModel, TransactionReadModel } from '../read-models';
 
-export class TransactionViewMapper {
-  static toView(transaction: TransactionReadModel): TransactionResponseDTO {
+export class TransactionReadModelResponseMapper {
+  static toResponseDTO(
+    transaction: TransactionReadModel,
+  ): TransactionResponseDTO {
     return {
       createdAt: transaction.createdAt,
       currency: transaction.currency,

--- a/apps/backend/src/application/mappers/transaction-read-model-response.mapper.ts
+++ b/apps/backend/src/application/mappers/transaction-read-model-response.mapper.ts
@@ -10,7 +10,9 @@ export class TransactionReadModelResponseMapper {
       currency: transaction.currency,
       description: transaction.description,
       id: transaction.id,
-      operations: transaction.operations.map(this.mapOperation.bind(this)),
+      // mapOperation does not access this, so passing it unbound is safe.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      operations: transaction.operations.map(this.mapOperation),
       postingDate: transaction.postingDate,
       transactionDate: transaction.transactionDate,
       updatedAt: transaction.updatedAt,

--- a/apps/backend/src/application/read-models/index.ts
+++ b/apps/backend/src/application/read-models/index.ts
@@ -1,0 +1,4 @@
+export type {
+  OperationReadModel,
+  TransactionReadModel,
+} from './transaction.read-model';

--- a/apps/backend/src/application/read-models/transaction.read-model.ts
+++ b/apps/backend/src/application/read-models/transaction.read-model.ts
@@ -1,0 +1,33 @@
+import {
+  CurrencyCode,
+  IsoDateString,
+  IsoDatetimeString,
+  MoneyString,
+  UUID,
+} from '@ledgerly/shared/types';
+
+export type OperationReadModel = {
+  accountId: UUID;
+  amount: MoneyString;
+  createdAt: IsoDatetimeString;
+  description: string;
+  id: UUID;
+  isSystem: boolean;
+  transactionId: UUID;
+  updatedAt: IsoDatetimeString;
+  userId: UUID;
+  value: MoneyString;
+};
+
+export type TransactionReadModel = {
+  createdAt: IsoDatetimeString;
+  currency: CurrencyCode;
+  description: string;
+  id: UUID;
+  operations: OperationReadModel[];
+  postingDate: IsoDateString;
+  transactionDate: IsoDateString;
+  updatedAt: IsoDatetimeString;
+  userId: UUID;
+  version: number;
+};

--- a/apps/backend/src/application/usecases/transaction/DeleteTransaction.ts
+++ b/apps/backend/src/application/usecases/transaction/DeleteTransaction.ts
@@ -22,6 +22,10 @@ export class DeleteTransactionUseCase {
         'Transaction',
       );
 
+      if (transaction.isDeleted()) {
+        return;
+      }
+
       transaction.markAsDeleted();
 
       await this.transactionRepository.softDelete(

--- a/apps/backend/src/application/usecases/transaction/GetAllTransactions.ts
+++ b/apps/backend/src/application/usecases/transaction/GetAllTransactions.ts
@@ -1,7 +1,7 @@
 import { TransactionQueryParams, UUID } from '@ledgerly/shared/types';
 import {
   TransactionListResponseDTO,
-  TransactionViewMapper,
+  TransactionReadModelResponseMapper,
 } from 'src/application';
 import {
   AccountRepositoryInterface,
@@ -34,7 +34,7 @@ export class GetAllTransactionsUseCase {
 
     return {
       items: items.map((transaction) =>
-        TransactionViewMapper.toView(transaction),
+        TransactionReadModelResponseMapper.toResponseDTO(transaction),
       ),
       pagination: {
         hasNextPage: page < totalPages,

--- a/apps/backend/src/application/usecases/transaction/GetTransactionById.ts
+++ b/apps/backend/src/application/usecases/transaction/GetTransactionById.ts
@@ -1,8 +1,8 @@
 import { UUID } from '@ledgerly/shared/types';
 import {
-  TransactionResponseDTO,
-  TransactionViewMapper,
   TransactionQueryRepositoryInterface,
+  TransactionReadModelResponseMapper,
+  TransactionResponseDTO,
 } from 'src/application';
 import { EntityNotFoundError } from 'src/application/application.errors';
 
@@ -23,6 +23,6 @@ export class GetTransactionByIdUseCase {
       throw new EntityNotFoundError('Transaction');
     }
 
-    return TransactionViewMapper.toView(transactionRecord);
+    return TransactionReadModelResponseMapper.toResponseDTO(transactionRecord);
   }
 }

--- a/apps/backend/src/application/usecases/transaction/__tests__/deleteTransaction.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/deleteTransaction.test.ts
@@ -1,4 +1,8 @@
 import {
+  EntityNotFoundError,
+  UnauthorizedAccessError,
+} from 'src/application/application.errors';
+import {
   TransactionManagerInterface,
   TransactionRepositoryInterface,
 } from 'src/application/interfaces';
@@ -78,9 +82,50 @@ describe('DeleteTransactionUseCase', () => {
     );
   });
 
-  it.todo('should propagate error when transaction is not found');
-  it.todo('should propagate error when user does not own the transaction');
-  it.todo(
-    'should be idempotent — calling delete on already-deleted transaction should not re-mark or re-increment version',
-  );
+  it('should propagate error when transaction is not found', async () => {
+    mockEnsureEntityExistsAndOwned.mockRejectedValue(
+      new EntityNotFoundError('Transaction'),
+    );
+
+    await expect(
+      deleteTransactionByIdUseCase.execute(user, transaction.getId().valueOf()),
+    ).rejects.toThrow(EntityNotFoundError);
+
+    expect(mockTransactionRepository.softDelete).not.toHaveBeenCalled();
+  });
+
+  it('should propagate error when user does not own the transaction', async () => {
+    mockEnsureEntityExistsAndOwned.mockRejectedValue(
+      new UnauthorizedAccessError('Transaction'),
+    );
+
+    await expect(
+      deleteTransactionByIdUseCase.execute(user, transaction.getId().valueOf()),
+    ).rejects.toThrow(UnauthorizedAccessError);
+
+    expect(mockTransactionRepository.softDelete).not.toHaveBeenCalled();
+  });
+
+  it('should be idempotent — calling delete on already-deleted transaction should not re-mark or re-increment version', async () => {
+    mockEnsureEntityExistsAndOwned.mockResolvedValue(transaction);
+
+    const initialVersion = transaction.getVersion().valueOf();
+
+    await deleteTransactionByIdUseCase.execute(
+      user,
+      transaction.getId().valueOf(),
+    );
+
+    const versionAfterFirstDelete = transaction.getVersion().valueOf();
+
+    await deleteTransactionByIdUseCase.execute(
+      user,
+      transaction.getId().valueOf(),
+    );
+
+    expect(transaction.isDeleted()).toBe(true);
+    expect(versionAfterFirstDelete).toBe(initialVersion + 1);
+    expect(transaction.getVersion().valueOf()).toBe(versionAfterFirstDelete);
+    expect(mockTransactionRepository.softDelete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/backend/src/application/usecases/transaction/__tests__/getAllTransactions.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/getAllTransactions.test.ts
@@ -5,7 +5,10 @@ import {
   AccountRepositoryInterface,
   TransactionQueryRepositoryInterface,
 } from 'src/application/interfaces';
-import { OperationDbRow, TransactionWithRelations } from 'src/db/schema';
+import {
+  OperationReadModel,
+  TransactionReadModel,
+} from 'src/application/read-models';
 import {
   Amount,
   Currency,
@@ -41,15 +44,14 @@ describe('GetAllTransactionsUseCase', () => {
   const buildOperation = (
     transactionId: UUID,
     userId: UUID,
-    overrides?: Partial<OperationDbRow>,
-  ): OperationDbRow => ({
+    overrides?: Partial<OperationReadModel>,
+  ): OperationReadModel => ({
     accountId: Id.create().valueOf(),
     amount: Amount.create('100').valueOf(),
     createdAt: Timestamp.create().valueOf(),
     description: 'Operation',
     id: Id.create().valueOf(),
     isSystem: false,
-    isTombstone: false,
     transactionId,
     updatedAt: Timestamp.create().valueOf(),
     userId,
@@ -57,7 +59,7 @@ describe('GetAllTransactionsUseCase', () => {
     ...overrides,
   });
 
-  const buildTransaction = (): TransactionWithRelations => {
+  const buildTransaction = (): TransactionReadModel => {
     const transactionId = Id.create().valueOf();
 
     return {
@@ -65,7 +67,6 @@ describe('GetAllTransactionsUseCase', () => {
       currency: Currency.create('USD').valueOf(),
       description: 'Test transaction',
       id: transactionId,
-      isTombstone: false,
       operations: [buildOperation(transactionId, userId)],
       postingDate: DateValue.restore('2024-01-01').valueOf(),
       transactionDate: DateValue.restore('2024-01-01').valueOf(),

--- a/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
@@ -1,9 +1,10 @@
 import {
-  TransactionResponseDTO,
+  OperationReadModel,
   TransactionQueryRepositoryInterface,
+  TransactionReadModel,
+  TransactionResponseDTO,
 } from 'src/application';
 import { EntityNotFoundError } from 'src/application/application.errors';
-import { OperationDbRow, TransactionWithRelations } from 'src/db/schema';
 import {
   Amount,
   Currency,
@@ -34,72 +35,40 @@ describe('GetTransactionByIdUseCase', () => {
     const createdAt = Timestamp.create().valueOf();
     const updatedAt = Timestamp.create().valueOf();
 
-    const mockOperation1: OperationDbRow = {
+    const mockOperation1: OperationReadModel = {
       accountId: Id.create().valueOf(),
       amount: Amount.create('1000').valueOf(),
       createdAt: Timestamp.create().valueOf(),
       description: 'Operation 1',
       id: Id.create().valueOf(),
       isSystem: false,
-      isTombstone: false,
       transactionId,
       updatedAt: Timestamp.create().valueOf(),
       userId,
       value: Amount.create('1000').valueOf(),
     };
 
-    const mockOperation2: OperationDbRow = {
+    const mockOperation2: OperationReadModel = {
       accountId: Id.create().valueOf(),
       amount: Amount.create('-1000').valueOf(),
       createdAt: Timestamp.create().valueOf(),
       description: 'Operation 2',
       id: Id.create().valueOf(),
       isSystem: false,
-      isTombstone: false,
       transactionId,
       updatedAt: Timestamp.create().valueOf(),
       userId,
       value: Amount.create('-1000').valueOf(),
     };
 
-    const mockOperation3: OperationDbRow = {
-      accountId: Id.create().valueOf(),
-      amount: Amount.create('500').valueOf(),
-      createdAt: Timestamp.create().valueOf(),
-      description: 'Deleted Operation 1',
-      id: Id.create().valueOf(),
-      isSystem: false,
-      isTombstone: true,
-      transactionId,
-      updatedAt: Timestamp.create().valueOf(),
-      userId,
-      value: Amount.create('500').valueOf(),
-    };
+    const operations = [mockOperation1, mockOperation2];
 
-    const mockOperation4: OperationDbRow = {
-      accountId: Id.create().valueOf(),
-      amount: Amount.create('-500').valueOf(),
-      createdAt: Timestamp.create().valueOf(),
-      description: 'Deleted Operation 2',
-      id: Id.create().valueOf(),
-      isSystem: false,
-      isTombstone: true,
-      transactionId,
-      updatedAt: Timestamp.create().valueOf(),
-      userId,
-      value: Amount.create('-500').valueOf(),
-    };
-
-    const deletedOperations = [mockOperation3, mockOperation4];
-    const nonDeletedOperations = [mockOperation1, mockOperation2];
-
-    const mockTransactionData: TransactionWithRelations = {
+    const mockTransactionData: TransactionReadModel = {
       createdAt,
       currency: Currency.create('USD').valueOf(),
       description: 'Test Transaction',
       id: transactionId,
-      isTombstone: false,
-      operations: [...deletedOperations, ...nonDeletedOperations],
+      operations,
       postingDate: DateValue.create().valueOf(),
       transactionDate: DateValue.create().valueOf(),
       updatedAt,
@@ -121,7 +90,7 @@ describe('GetTransactionByIdUseCase', () => {
     expect(transaction.description).toBe('Test Transaction');
     expect(transaction.version).toBe(mockTransactionData.version);
     expect(transaction).not.toHaveProperty('isTombstone');
-    expect(transaction.operations).toHaveLength(nonDeletedOperations.length);
+    expect(transaction.operations).toHaveLength(operations.length);
 
     transaction.operations.forEach(
       (operation: TransactionResponseDTO['operations'][number]) => {

--- a/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/getTransactionById.test.ts
@@ -89,11 +89,39 @@ describe('GetTransactionByIdUseCase', () => {
     expect(transaction.id).toBe(transactionId);
     expect(transaction.description).toBe('Test Transaction');
     expect(transaction.version).toBe(mockTransactionData.version);
+    expect(Object.keys(transaction).sort()).toEqual(
+      [
+        'createdAt',
+        'currency',
+        'description',
+        'id',
+        'operations',
+        'postingDate',
+        'transactionDate',
+        'updatedAt',
+        'userId',
+        'version',
+      ].sort(),
+    );
     expect(transaction).not.toHaveProperty('isTombstone');
     expect(transaction.operations).toHaveLength(operations.length);
 
     transaction.operations.forEach(
       (operation: TransactionResponseDTO['operations'][number]) => {
+        expect(Object.keys(operation).sort()).toEqual(
+          [
+            'accountId',
+            'amount',
+            'createdAt',
+            'description',
+            'id',
+            'isSystem',
+            'transactionId',
+            'updatedAt',
+            'userId',
+            'value',
+          ].sort(),
+        );
         expect(operation).not.toHaveProperty('isTombstone');
       },
     );

--- a/apps/backend/src/application/usecases/transaction/__tests__/updateTransaction.test.ts
+++ b/apps/backend/src/application/usecases/transaction/__tests__/updateTransaction.test.ts
@@ -2,6 +2,7 @@ import type { UUID } from '@ledgerly/shared/types';
 import { OperationMapper, TransactionMapper } from 'src/application';
 import {
   EntityNotFoundError,
+  UnauthorizedAccessError,
   VersionConflictError,
 } from 'src/application/application.errors';
 import {
@@ -461,8 +462,35 @@ describe('UpdateTransactionUseCase', () => {
     await expectRejectedWithoutPersistence(data, ConflictingOperationIdsError);
   });
 
-  it.todo('should propagate error when transaction is not found');
-  it.todo('should propagate error when user does not own the transaction');
+  it('propagates an error when the transaction is not found', async () => {
+    const data = createRequest({
+      description: 'Unknown transaction',
+    });
+
+    mockEnsureEntityExistsAndOwned.mockRejectedValue(
+      new EntityNotFoundError('Transaction'),
+    );
+
+    await expect(execute(data)).rejects.toThrow(EntityNotFoundError);
+
+    expect(mockTransactionRepository.update).not.toHaveBeenCalled();
+    expect(mockTransactionContextLoader.loadContext).not.toHaveBeenCalled();
+  });
+
+  it('propagates an error when user does not own the transaction', async () => {
+    const data = createRequest({
+      description: 'Unauthorized transaction update',
+    });
+
+    mockEnsureEntityExistsAndOwned.mockRejectedValue(
+      new UnauthorizedAccessError('Transaction'),
+    );
+
+    await expect(execute(data)).rejects.toThrow(UnauthorizedAccessError);
+
+    expect(mockTransactionRepository.update).not.toHaveBeenCalled();
+    expect(mockTransactionContextLoader.loadContext).not.toHaveBeenCalled();
+  });
 
   it('throws a version conflict error when request version is stale', async () => {
     const data = createRequest({

--- a/apps/backend/src/di/container.ts
+++ b/apps/backend/src/di/container.ts
@@ -54,7 +54,6 @@ export const createContainer = (db: DataBase): AppContainer => {
   const repositories: AppContainer['repositories'] = {
     account: accountRepository,
     currency: currencyRepository,
-    operation: operationRepository,
     transaction: transactionRepository,
     transactionQuery: transactionQueryRepository,
     user: userRepository,

--- a/apps/backend/src/di/types.ts
+++ b/apps/backend/src/di/types.ts
@@ -18,7 +18,6 @@ import {
   TransactionQueryRepository,
   AccountRepository,
   CurrencyRepository,
-  OperationRepository,
   TransactionRepository,
   UserRepository,
 } from 'src/infrastructure/db';
@@ -35,7 +34,6 @@ type Repositories = {
   transactionQuery: TransactionQueryRepository;
   account: AccountRepository;
   user: UserRepository;
-  operation: OperationRepository;
 };
 
 type Services = {

--- a/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.test.ts
@@ -484,7 +484,7 @@ describe('TransactionQueryRepository', () => {
       );
 
       result.items.forEach((transaction) => {
-        expect(transaction.isTombstone).toBeFalsy();
+        expect(transaction).not.toHaveProperty('isTombstone');
       });
     });
   });
@@ -638,7 +638,7 @@ describe('TransactionQueryRepository', () => {
       );
 
       transaction?.operations.forEach((op) => {
-        expect(op.isTombstone).toBe(false);
+        expect(op).not.toHaveProperty('isTombstone');
       });
     });
   });

--- a/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.test.ts
@@ -487,6 +487,67 @@ describe('TransactionQueryRepository', () => {
         expect(transaction).not.toHaveProperty('isTombstone');
       });
     });
+
+    it('should return application read model shape without persistence-only fields', async () => {
+      await createTransaction({
+        description: 'Read model contract',
+        operations: [
+          {
+            account: usdAccount,
+            amount: '-100' as MoneyString,
+            description: 'Contract debit',
+          },
+          {
+            account: eurAccount,
+            amount: '100' as MoneyString,
+            description: 'Contract credit',
+          },
+        ],
+      });
+
+      const result = await transactionQueryRepo.findAll(
+        user.id,
+        DEFAULT_TRANSACTION_QUERY,
+      );
+
+      expect(result.items).toHaveLength(1);
+
+      const transaction = result.items[0];
+
+      expect(Object.keys(transaction).sort()).toEqual(
+        [
+          'createdAt',
+          'currency',
+          'description',
+          'id',
+          'operations',
+          'postingDate',
+          'transactionDate',
+          'updatedAt',
+          'userId',
+          'version',
+        ].sort(),
+      );
+      expect(transaction).not.toHaveProperty('isTombstone');
+
+      transaction.operations.forEach((operation) => {
+        expect(Object.keys(operation).sort()).toEqual(
+          [
+            'accountId',
+            'amount',
+            'createdAt',
+            'description',
+            'id',
+            'isSystem',
+            'transactionId',
+            'updatedAt',
+            'userId',
+            'value',
+          ].sort(),
+        );
+        expect(operation).not.toHaveProperty('isTombstone');
+      });
+    });
   });
 
   describe('findById', () => {

--- a/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction-query.repository.ts
@@ -4,17 +4,16 @@ import {
   PaginatedResult,
   TransactionQueryRepositoryInterface,
 } from 'src/application/interfaces';
-import {
-  operationsTable,
-  transactionsTable,
-  TransactionWithRelations,
-} from 'src/db/schema';
+import { TransactionReadModel } from 'src/application/read-models';
+import { operationsTable, transactionsTable } from 'src/db/schema';
 
 import { BaseRepository } from '../BaseRepository';
 
+import { TransactionReadModelMapper } from './transaction-read-model.mapper';
+
 /**
  * Query repository for read-only transaction operations.
- * Returns DTOs optimized for display without full domain model restoration.
+ * Maps persistence rows to application read models.
  */
 export class TransactionQueryRepository
   extends BaseRepository
@@ -29,7 +28,7 @@ export class TransactionQueryRepository
   async findById(
     userId: UUID,
     transactionId: UUID,
-  ): Promise<TransactionWithRelations | null> {
+  ): Promise<TransactionReadModel | null> {
     return this.executeDatabaseOperation(
       async () => {
         const transaction = await this.db.query.transactionsTable.findFirst({
@@ -45,7 +44,9 @@ export class TransactionQueryRepository
           },
         });
 
-        return transaction ?? null;
+        return transaction
+          ? TransactionReadModelMapper.fromPersistence(transaction)
+          : null;
       },
       'TransactionQueryRepository.findById',
       {
@@ -59,7 +60,7 @@ export class TransactionQueryRepository
   async findAll(
     userId: UUID,
     query: TransactionQueryParams,
-  ): Promise<PaginatedResult<TransactionWithRelations>> {
+  ): Promise<PaginatedResult<TransactionReadModel>> {
     return this.executeDatabaseOperation(
       async () => {
         // TODO(LED-60): benchmark EXISTS and single-query count alternatives;
@@ -124,7 +125,9 @@ export class TransactionQueryRepository
           .where(transactionWhereConditions);
 
         return {
-          items,
+          items: items.map((transaction) =>
+            TransactionReadModelMapper.fromPersistence(transaction),
+          ),
           total: countResult.total,
         };
       },

--- a/apps/backend/src/infrastructure/db/transaction/transaction-read-model.mapper.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction-read-model.mapper.ts
@@ -1,8 +1,13 @@
-import { OperationResponseDTO, TransactionResponseDTO } from '../dto';
-import { OperationReadModel, TransactionReadModel } from '../read-models';
+import {
+  OperationReadModel,
+  TransactionReadModel,
+} from 'src/application/read-models';
+import { OperationDbRow, TransactionWithRelations } from 'src/db/schema';
 
-export class TransactionViewMapper {
-  static toView(transaction: TransactionReadModel): TransactionResponseDTO {
+export class TransactionReadModelMapper {
+  static fromPersistence(
+    transaction: TransactionWithRelations,
+  ): TransactionReadModel {
     return {
       createdAt: transaction.createdAt,
       currency: transaction.currency,
@@ -17,9 +22,7 @@ export class TransactionViewMapper {
     };
   }
 
-  private static mapOperation(
-    operation: OperationReadModel,
-  ): OperationResponseDTO {
+  private static mapOperation(operation: OperationDbRow): OperationReadModel {
     return {
       accountId: operation.accountId,
       amount: operation.amount,

--- a/apps/backend/src/infrastructure/db/transaction/transaction-read-model.mapper.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction-read-model.mapper.ts
@@ -13,7 +13,9 @@ export class TransactionReadModelMapper {
       currency: transaction.currency,
       description: transaction.description,
       id: transaction.id,
-      operations: transaction.operations.map(this.mapOperation.bind(this)),
+      // mapOperation does not access this, so passing it unbound is safe.
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      operations: transaction.operations.map(this.mapOperation),
       postingDate: transaction.postingDate,
       transactionDate: transaction.transactionDate,
       updatedAt: transaction.updatedAt,

--- a/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
+++ b/apps/backend/src/infrastructure/db/transaction/transaction.repository.ts
@@ -24,7 +24,7 @@ export class TransactionRepository
   implements TransactionRepositoryInterface
 {
   constructor(
-    readonly operationsRepository: OperationRepositoryInterface,
+    private readonly operationsRepository: OperationRepositoryInterface,
     readonly transactionManager: BaseRepository['transactionManager'],
   ) {
     super(transactionManager);

--- a/docs/architecture/adr/0001-transaction-repository-boundaries.md
+++ b/docs/architecture/adr/0001-transaction-repository-boundaries.md
@@ -1,0 +1,72 @@
+# ADR 0001: Transaction repository boundaries
+
+- Status: Accepted
+- Date: 2026-06-14
+- Jira: https://gorushkin.atlassian.net/browse/LED-37
+- PR: TBD
+
+## Context
+
+В backend есть два репозитория транзакций:
+
+- `TransactionRepository` для command/write-side;
+- `TransactionQueryRepository` для query/read-side.
+
+Разделение уже применялось в use cases, но не было полностью закреплено контрактами.
+Это допускало утечки persistence-деталей в application слой:
+
+- импорт db schema-типов в transaction read flow;
+- раскрытие внутренних write-side деталей через публичный интерфейс.
+
+Такая связность делала архитектурную границу соглашением, которое легко нарушить
+при изменениях.
+
+## Decision
+
+Принято разделение ответственности transaction repositories через явные
+application contracts:
+
+1. `TransactionRepositoryInterface` остается write-side контрактом агрегата и не
+   раскрывает внутренние collaborators.
+2. `TransactionQueryRepositoryInterface` возвращает application-level
+   `TransactionReadModel`, а не db schema/row типы и не доменный агрегат.
+3. Mapping `DB rows -> TransactionReadModel` выполняется в infrastructure query
+   repository.
+4. Tombstone policy для read-side применяется в query repository до mapping.
+5. Преобразование `TransactionReadModel -> TransactionResponseDTO` выполняется
+   отдельным mapper (`TransactionReadModelResponseMapper`) на application уровне.
+
+## Alternatives Considered
+
+1. Возвращать из query repository сразу `TransactionResponseDTO`.
+
+- Плюс: меньше одного mapper-слоя.
+- Минус: repository contract становится зависим от внешнего API формата.
+
+2. Продолжать использовать db schema-типы в application read flow.
+
+- Плюс: меньше промежуточных типов.
+- Минус: нарушение границы слоев и рост связанности с persistence.
+
+3. Открыть `OperationRepository` через `TransactionRepositoryInterface`.
+
+- Плюс: прямая точка записи операций.
+- Минус: риск обхода границы агрегата `Transaction`.
+
+## Consequences
+
+Положительные:
+
+- Граница read/write закреплена контрактами, а не соглашением.
+- Application transaction read flow не зависит от `src/db/schema`.
+- Публичный write-side контракт стал уже и безопаснее для эволюции агрегата.
+
+Нейтральные/стоимость:
+
+- Появляется отдельная read-model и mapper между read-model и response DTO.
+- Требуется поддерживать тесты shape-контракта для query read model.
+
+## Related
+
+- План задачи: `docs/plans/LED-37-transaction-repository-boundaries.md`
+- Документация домена: `docs/DOMAIN.md`

--- a/docs/architecture/adr/0001-transaction-repository-boundaries.md
+++ b/docs/architecture/adr/0001-transaction-repository-boundaries.md
@@ -3,7 +3,7 @@
 - Status: Accepted
 - Date: 2026-06-14
 - Jira: https://gorushkin.atlassian.net/browse/LED-37
-- PR: TBD
+- PR: https://github.com/gorushkin/ledgerly/pull/196
 
 ## Context
 
@@ -68,5 +68,5 @@ application contracts:
 
 ## Related
 
-- План задачи: `docs/plans/LED-37-transaction-repository-boundaries.md`
+- План задачи: `docs/archive/plans/LED-37-transaction-repository-boundaries.md`
 - Документация домена: `docs/DOMAIN.md`

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records (ADR)
+
+Этот каталог хранит архитектурные решения проекта в формате ADR.
+
+## Как писать ADR
+
+- Один файл = одно решение.
+- Именование: `NNNN-short-kebab-case-title.md`.
+- Статусы: `Proposed`, `Accepted`, `Superseded`, `Deprecated`.
+- ADR должен ссылаться на Jira и PR, если они есть.
+
+## Рекомендуемый шаблон
+
+```md
+# ADR NNNN: Заголовок
+
+- Status: Proposed|Accepted|Superseded|Deprecated
+- Date: YYYY-MM-DD
+- Jira: <link-or-N/A>
+- PR: <link-or-TBD>
+
+## Context
+
+## Decision
+
+## Alternatives Considered
+
+## Consequences
+
+## Related
+```
+
+## Индекс
+
+- [ADR 0001: Transaction repository boundaries](./0001-transaction-repository-boundaries.md)

--- a/docs/archive/plans/LED-37-transaction-repository-boundaries.md
+++ b/docs/archive/plans/LED-37-transaction-repository-boundaries.md
@@ -2,7 +2,7 @@
 
 Jira: https://gorushkin.atlassian.net/browse/LED-37
 
-Статус документа: выполнено (ожидает PR).
+Статус документа: выполнено.
 
 ## Контекст
 
@@ -98,8 +98,9 @@ schema.
 
 - [x] Добавить короткие комментарии к обоим repository interfaces.
 - [x] Проверить отсутствие DB schema imports в application query contract.
-- [ ] Связать этот документ с Jira-задачей и итоговым pull request.
-      Jira уже добавлена, ссылка на PR будет добавлена после открытия PR для ветки.
+- [x] Связать этот документ с Jira-задачей и итоговым pull request.
+      Jira: https://gorushkin.atlassian.net/browse/LED-37
+      PR: https://github.com/gorushkin/ledgerly/pull/196
 
 ## Критерии завершения
 

--- a/docs/plans/LED-37-transaction-repository-boundaries.md
+++ b/docs/plans/LED-37-transaction-repository-boundaries.md
@@ -1,0 +1,136 @@
+# LED-37: Граница ответственности transaction repositories
+
+Jira: https://gorushkin.atlassian.net/browse/LED-37
+
+Статус документа: выполнено (ожидает PR).
+
+## Контекст
+
+В backend существуют два репозитория транзакций:
+
+- `TransactionRepository` обслуживает command/write-side;
+- `TransactionQueryRepository` обслуживает query/read-side.
+
+Фактическое разделение уже используется в use cases, но не полностью закреплено
+контрактами. Application layer импортирует read-модель непосредственно из
+database schema, а write-side интерфейс публично раскрывает
+`operationsRepository`.
+
+Из-за этого граница остается соглашением, которое легко нарушить при следующих
+изменениях.
+
+## Целевая граница
+
+### TransactionRepository
+
+Отвечает за persistence агрегата `Transaction`:
+
+- создание агрегата;
+- восстановление агрегата для command-сценариев;
+- сохранение изменений с optimistic locking;
+- soft delete агрегата;
+- внутреннее сохранение входящих в агрегат операций.
+
+Контракт возвращает и принимает доменные типы. Детали таблиц, DB rows и
+вложенные infrastructure repositories не являются частью публичного
+интерфейса.
+
+### TransactionQueryRepository
+
+Отвечает за read-модель транзакций:
+
+- чтение одной транзакции;
+- списки, фильтрацию, сортировку и pagination;
+- исключение архивных данных согласно read policy;
+- формирование стабильного application-level query shape.
+
+Контракт не возвращает доменный агрегат и не раскрывает типы Drizzle/database
+schema.
+
+## План
+
+### 1. Зафиксировать application-level read model
+
+- [x] Определить `TransactionReadModel` и `OperationReadModel`.
+- [x] Разместить типы в application layer рядом с query repository contract.
+- [x] Включить только данные, необходимые текущим read use cases и API.
+- [x] Не переносить в read model persistence-only поля без потребности API.
+
+### 2. Изолировать query repository от database schema
+
+- [x] Изменить `TransactionQueryRepositoryInterface`, чтобы он возвращал
+      application-level read model.
+- [x] Преобразовывать DB rows в read model внутри infrastructure query
+      repository.
+- [x] Убрать импорты `TransactionWithRelations` и `OperationDbRow` из
+      application interfaces, use cases, mappers и их unit-тестов.
+- [x] Оставить фильтрацию tombstone-записей ответственностью query repository.
+
+### 3. Закрыть write-side контракт
+
+- [x] Удалить `operationsRepository` из `TransactionRepositoryInterface`.
+- [x] Сделать dependency на `OperationRepositoryInterface` приватной деталью
+      реализации `TransactionRepository`.
+- [x] Проверить, что операции сохраняются только как часть persistence
+      агрегата `Transaction`.
+- [x] Сохранить `getById()` в write repository: он восстанавливает агрегат для
+      update/delete и не является read API.
+
+### 4. Упростить mapping
+
+- [x] Решить, должен ли query repository возвращать готовый
+      `TransactionResponseDTO` или отдельный `TransactionReadModel`.
+- [x] Предпочесть отдельный read model, если API DTO не должен определять
+      repository contract.
+- [x] Удалить дублирующую фильтрацию tombstone-операций из mapper после
+      закрепления read policy.
+- [x] Переименовать mapper так, чтобы источник и назначение преобразования были
+      очевидны.
+
+### 5. Проверить границу тестами
+
+- [x] Обновить unit-тесты read use cases: они не должны импортировать DB schema.
+- [x] Обновить тесты `TransactionQueryRepository` для нового read shape.
+- [x] Проверить create/update/delete use cases с закрытым write contract.
+- [x] Запустить backend typecheck, unit и repository/integration tests.
+
+### 6. Зафиксировать правило
+
+- [x] Добавить короткие комментарии к обоим repository interfaces.
+- [x] Проверить отсутствие DB schema imports в application query contract.
+- [ ] Связать этот документ с Jira-задачей и итоговым pull request.
+      Jira уже добавлена, ссылка на PR будет добавлена после открытия PR для ветки.
+
+## Критерии завершения
+
+- `TransactionRepositoryInterface` оперирует только агрегатом и результатами
+  write-side persistence.
+- `TransactionQueryRepositoryInterface` возвращает application-level
+  read-модель.
+- Application layer не зависит от `src/db/schema` в transaction read flow.
+- `OperationRepositoryInterface` не раскрывается через публичный transaction
+  repository contract.
+- Tombstone policy применяется в одном определенном месте.
+- Все затронутые тесты проходят.
+
+## Не входит в задачу
+
+- изменение внешнего REST API без необходимости;
+- переход на event sourcing;
+- хранение полной истории изменений транзакции;
+- выделение операций в отдельный aggregate;
+- создание отдельных operation use cases.
+
+## Решения и изменения плана
+
+Этот раздел содержит только решения, влияющие на архитектуру или объем задачи.
+Подробный дневник реализации вести не нужно.
+
+| Дата | Решение | Причина |
+|---|---|---|
+| 2026-06-14 | Разделить command aggregate persistence и query read model явными application contracts | Текущие контракты допускают утечку DB schema и внутренних repository dependencies |
+| 2026-06-14 | Определить read model независимо от REST DTO, даже при совпадающей текущей структуре | Изменения внешнего API и внутреннего query contract должны эволюционировать независимо |
+| 2026-06-14 | Разместить mapping DB rows → read model внутри infrastructure | DB schema не должна пересекать границу application layer |
+| 2026-06-14 | Применять tombstone policy в SQL query repository, до mapping в read model | Архивные признаки являются persistence detail и не входят в application read model |
+| 2026-06-14 | Оставить `OperationRepository` внутренним collaborator `TransactionRepository` и не публиковать его через application container | Операции сохраняются в границе агрегата транзакции; отдельная публичная точка записи позволяла бы обойти эту границу |
+| 2026-06-14 | Сохранять отдельные `TransactionReadModel` и `TransactionResponseDTO`; преобразовывать их через `TransactionReadModelResponseMapper` | Repository query contract и внешний REST contract должны изменяться независимо |


### PR DESCRIPTION
## Summary

Closes https://gorushkin.atlassian.net/browse/LED-37

Enforces explicit application contracts between write-side and read-side transaction repositories.

### Changes

- Defined `TransactionReadModel` / `OperationReadModel` in application layer
- `TransactionQueryRepositoryInterface` now returns application read model (no db schema types)
- DB rows → read model mapping moved into infrastructure query repository
- Tombstone policy applied in query repository before mapping
- Removed `operationsRepository` from `TransactionRepositoryInterface`
- Added `TransactionReadModelResponseMapper` (read model → response DTO)
- Hardened use-case tests: propagation of not-found/unauthorized errors, delete idempotency
- Added read model shape contract tests in query repository
- Added ADR 0001 documenting the decision

### Architecture Decision Record

See `docs/architecture/adr/0001-transaction-repository-boundaries.md`