### PR TITLE
LED-127 test: add TransactionManager tests for nested transaction context reuse

### DIFF
--- a/apps/backend/src/infrastructure/db/TransactionManager.test.ts
+++ b/apps/backend/src/infrastructure/db/TransactionManager.test.ts
@@ -1,3 +1,4 @@
+import type { TransactionContext } from 'src/application/interfaces';
 import type { DataBase, TxType } from 'src/db';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -14,19 +15,24 @@ describe('TransactionManager', () => {
     } as unknown as DataBase;
     const transactionManager = new TransactionManager(db);
 
-    const result = await transactionManager.run(async () => {
-      const outerTransaction = transactionManager.getCurrentTransaction();
+    let outerContext: TransactionContext | undefined;
 
-      return await transactionManager.run(() => {
+    const result = await transactionManager.run(async (context) => {
+      const outerTransaction = transactionManager.getCurrentTransaction();
+      outerContext = context;
+
+      return await transactionManager.run((nestedContext) => {
         expect(transactionManager.getCurrentTransaction()).toBe(
           outerTransaction,
         );
+        expect(nestedContext).toBe(outerContext);
 
         return Promise.resolve('nested result');
       });
     });
 
     expect(result).toBe('nested result');
+    expect(outerContext).toEqual({});
     expect(transaction).toHaveBeenCalledTimes(1);
     expect(transactionManager.getCurrentTransaction()).toBe(db);
   });

--- a/apps/backend/src/infrastructure/db/TransactionManager.test.ts
+++ b/apps/backend/src/infrastructure/db/TransactionManager.test.ts
@@ -1,0 +1,33 @@
+import type { DataBase, TxType } from 'src/db';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TransactionManager } from './TransactionManager';
+
+describe('TransactionManager', () => {
+  it('reuses the current transaction context for nested run calls', async () => {
+    const tx = { id: 'tx' } as unknown as TxType;
+    const transaction = vi.fn((callback: (tx: TxType) => Promise<string>) =>
+      callback(tx),
+    );
+    const db = {
+      transaction,
+    } as unknown as DataBase;
+    const transactionManager = new TransactionManager(db);
+
+    const result = await transactionManager.run(async () => {
+      const outerTransaction = transactionManager.getCurrentTransaction();
+
+      return await transactionManager.run(() => {
+        expect(transactionManager.getCurrentTransaction()).toBe(
+          outerTransaction,
+        );
+
+        return Promise.resolve('nested result');
+      });
+    });
+
+    expect(result).toBe('nested result');
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transactionManager.getCurrentTransaction()).toBe(db);
+  });
+});

--- a/apps/backend/src/infrastructure/db/TransactionManager.ts
+++ b/apps/backend/src/infrastructure/db/TransactionManager.ts
@@ -17,12 +17,12 @@ export class TransactionManager implements TransactionManagerInterface {
   async run<T>(
     callback: (context?: TransactionContext) => Promise<T>,
   ): Promise<T> {
-    return await this.db.transaction(async (tx: TxType) => {
-      const existingStore = this.storage.getStore();
-      if (existingStore) {
-        return await callback();
-      }
+    const existingStore = this.storage.getStore();
+    if (existingStore) {
+      return await callback();
+    }
 
+    return await this.db.transaction(async (tx: TxType) => {
       return this.storage.run({ tx }, async () => {
         try {
           return await callback({});

--- a/apps/backend/src/infrastructure/db/TransactionManager.ts
+++ b/apps/backend/src/infrastructure/db/TransactionManager.ts
@@ -7,6 +7,7 @@ import type {
 import { DataBase, TxType } from 'src/db';
 
 type Store = {
+  context: TransactionContext;
   tx: TxType;
 };
 
@@ -19,13 +20,15 @@ export class TransactionManager implements TransactionManagerInterface {
   ): Promise<T> {
     const existingStore = this.storage.getStore();
     if (existingStore) {
-      return await callback();
+      return await callback(existingStore.context);
     }
 
     return await this.db.transaction(async (tx: TxType) => {
-      return this.storage.run({ tx }, async () => {
+      const context: TransactionContext = {};
+
+      return this.storage.run({ context, tx }, async () => {
         try {
-          return await callback({});
+          return await callback(context);
         } catch (error) {
           if (process.env.NODE_ENV !== 'test') {
             console.error('Transaction error, rolling back');

--- a/apps/backend/src/infrastructure/db/user/user.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/user/user.repository.test.ts
@@ -2,7 +2,10 @@ import { UserRepositoryInterface } from 'src/application';
 import { Email, Id, Name, Password } from 'src/domain/domain-core';
 import { User } from 'src/domain/users/user.entity';
 import { TransactionManager } from 'src/infrastructure/db';
-import { RepositoryNotFoundError } from 'src/infrastructure/errors';
+import {
+  RecordAlreadyExistsError,
+  RepositoryNotFoundError,
+} from 'src/infrastructure/errors';
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 
 import { UserRepository } from '../';
@@ -196,6 +199,20 @@ describe('UsersRepository', () => {
       );
 
       expect(user1.id).not.toBe(user2.id);
+    });
+
+    it('throws RecordAlreadyExistsError for duplicate email', async () => {
+      await userRepository.create(await createUser());
+
+      await expect(userRepository.create(await createUser())).rejects.toThrow(
+        new RecordAlreadyExistsError({
+          context: {
+            field: 'email',
+            tableName: 'users',
+            value: email,
+          },
+        }),
+      );
     });
   });
 

--- a/apps/backend/src/infrastructure/db/user/user.repository.test.ts
+++ b/apps/backend/src/infrastructure/db/user/user.repository.test.ts
@@ -204,7 +204,9 @@ describe('UsersRepository', () => {
     it('throws RecordAlreadyExistsError for duplicate email', async () => {
       await userRepository.create(await createUser());
 
-      await expect(userRepository.create(await createUser())).rejects.toThrow(
+      await expect(
+        userRepository.create(await createUser()),
+      ).rejects.toThrowError(
         new RecordAlreadyExistsError({
           context: {
             field: 'email',

--- a/apps/backend/src/infrastructure/db/user/user.repository.ts
+++ b/apps/backend/src/infrastructure/db/user/user.repository.ts
@@ -136,6 +136,13 @@ export class UserRepository
       async () =>
         this.db.insert(usersTable).values(data).returning(userSelect).get(),
       'Failed to create user',
+      {
+        unique: {
+          field: 'email',
+          tableName: 'users',
+          value: data.email,
+        },
+      },
     );
   }
 


### PR DESCRIPTION
feat: throw RecordAlreadyExistsError for duplicate email in user creation